### PR TITLE
Add 'smtp_sender' to list of parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,20 @@ You can pass the necessary parameters with the -d option. List of available para
 
 `'influx_host': '<influx_host_DNS_or_IP>'` - required for all type of notifications
 
-`'smpt_user': '<smpt_user_who_will_send_email>'` - required for all type of notifications
+`'smpt_user': '<smpt_user_who_will_login_to_the_the_host>'` - required for all type of notifications - note: parameter name smpt instead of smtp
 
-`'smpt_password': '<password>'` - required for all type of notifications
+`'smpt_password': '<password>'` - required for all type of notifications - note: parameter name smpt instead of smtp
+
+`'smpt_sender': '<sender_who_email_will_be_FROM>'` - optional: if not included then 'smpt_user' will be used - note: parameter name smpt instead of smtp
 
 `'user_list': '<list of recipients>'` - required for all type of notifications
 
 `'notification_type': '<test_type>'` - should be 'ui' or 'api'
 
+`'smpt_host': 'smtp.gmail.com'` - optional, default - 'smtp.gmail.com' - note: parameter name smpt instead of smtp
 
-`'smpt_host': 'smtp.gmail.com'` - optional, default - 'smtp.gmail.com'
- 
-`'smpt_port': 465` - optional, default - 465
- 
+`'smpt_port': 465` - optional, default - 465 - note: parameter name smpt instead of smtp
+
 `'influx_port': 8086` - optional, default - 8086
 
 `'influx_thresholds_database': 'thresholds'` - optional, default - 'thresholds'

--- a/README.md
+++ b/README.md
@@ -32,19 +32,19 @@ You can pass the necessary parameters with the -d option. List of available para
 
 `'influx_host': '<influx_host_DNS_or_IP>'` - required for all type of notifications
 
-`'smpt_user': '<smpt_user_who_will_login_to_the_the_host>'` - required for all type of notifications - note: parameter name smpt instead of smtp
+`'smpt_user': '<smpt_user_who_will_login_to_the_the_host>'` - required for all type of notifications - note: parameter name `smpt` instead of `smtp`
 
-`'smpt_password': '<password>'` - required for all type of notifications - note: parameter name smpt instead of smtp
+`'smpt_password': '<password>'` - required for all type of notifications - note: parameter name `smpt` instead of `smtp`
 
-`'smpt_sender': '<sender_who_email_will_be_FROM>'` - optional: if not included then 'smpt_user' will be used - note: parameter name smpt instead of smtp
+`'smpt_sender': '<sender_who_email_will_be_FROM>'` - optional: if not included then 'smpt_user' will be used - note: parameter name `smpt` instead of `smtp`
 
 `'user_list': '<list of recipients>'` - required for all type of notifications
 
 `'notification_type': '<test_type>'` - should be 'ui' or 'api'
 
-`'smpt_host': 'smtp.gmail.com'` - optional, default - 'smtp.gmail.com' - note: parameter name smpt instead of smtp
+`'smpt_host': 'smtp.gmail.com'` - optional, default - 'smtp.gmail.com' - note: parameter name `smpt` instead of `smtp`
 
-`'smpt_port': 465` - optional, default - 465 - note: parameter name smpt instead of smtp
+`'smpt_port': 465` - optional, default - 465 - note: parameter name `smpt` instead of `smtp`
 
 `'influx_port': 8086` - optional, default - 8086
 

--- a/email_notifications.py
+++ b/email_notifications.py
@@ -24,6 +24,8 @@ class EmailNotification:
         self.args = arguments
         self.data_manager = DataManager(arguments)
         self.report_builder = ReportBuilder()
+        
+        #TODO correct all parameters to be 'smtp' rather than 'smpt' which is incorrect
         self.smtp_config = {'host': arguments['smpt_host'],
                             'port': arguments['smpt_port'],
                             'user': arguments['smpt_user'],

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -71,6 +71,7 @@ def parse_args(_event):
     args['smpt_port'] = event.get("smpt_port", 465)
     args['smpt_host'] = event.get("smpt_host", "smtp.gmail.com")
     args['smpt_user'] = environ.get('smpt_user') if not event.get('smpt_user') else event.get('smpt_user')
+    args['smpt_sender'] = event.get('smpt_user') if not event.get('smpt_sender') else event.get('smpt_sender')
     if not event.get('smpt_password'):
         args['smpt_password'] = environ.get("smpt_password")
     else:


### PR DESCRIPTION
Add 'smtp_sender' to list of parameters to allow setting "FROM" email address. 

closes https://github.com/carrier-io/carrier-io/issues/35