### PR TITLE
Fix UI report

### DIFF
--- a/templates/ui_email_template.html
+++ b/templates/ui_email_template.html
@@ -43,12 +43,14 @@
                     <img src="succeed.png" alt="">
                 </div>
             </td>
+            {% if baseline_comparison_actions %}
             <td style="background: #F6F9FC; padding: 4px 12px;">
                 <div style="color: #32325D; font-size: 16px; font-weight: 400;">
                     <span style="margin-right: 30px">Baseline: {{ t_params.degradation_rate }}%</span>
                     <img src="succeed.png" alt="">
                 </div>
             </td>
+            {% endif %}
         </tr>
     </table>
     <div style="margin-top: 24px;">
@@ -57,20 +59,14 @@
             <tr>
                 <td style="border-bottom: solid 1px #EAEDEF; color: #32325D; padding: 4px 12px; font-weight: 600; width: 25%;">Scenario:</td>
                 <td style="border-bottom: solid 1px #EAEDEF; color: #525F7F; padding: 4px 12px; width: 25%;">{{ t_params.scenario }}</td>
-                <td style="border-bottom: solid 1px #EAEDEF; color: #32325D; padding: 4px 12px; font-weight: 600; width: 25%;">View port:</td>
-                <td style="border-bottom: solid 1px #EAEDEF; color: #525F7F; padding: 4px 12px; width: 25%;">{{ t_params.view_port }}</td>
-            </tr>
-            <tr>
-                <td style="border-bottom: solid 1px #EAEDEF; color: #32325D; padding: 4px 12px; font-weight: 600; width: 25%;">Duration:</td>
-                <td style="border-bottom: solid 1px #EAEDEF; color: #525F7F; padding: 4px 12px; width: 25%;">{{ t_params.duration }}</td>
-                <td style="border-bottom: solid 1px #EAEDEF; color: #32325D; padding: 4px 12px; font-weight: 600; width: 25%;">Reasons:</td>
-                <td style="border-bottom: solid 1px #EAEDEF; color: #525F7F; padding: 4px 12px; width: 25%;">{{ error_message }}</td>
+                <td style="border-bottom: solid 1px #EAEDEF; color: #32325D; padding: 4px 12px; font-weight: 600; width: 25%;">Start time:</td>
+                <td style="border-bottom: solid 1px #EAEDEF; color: #525F7F; padding: 4px 12px; width: 25%;">{{ t_params.start_time }}</td>
             </tr>
             <tr>
                 <td style="border-bottom: solid 1px #EAEDEF; color: #32325D; padding: 4px 12px; font-weight: 600; width: 25%;">Env:</td>
                 <td style="border-bottom: solid 1px #EAEDEF; color: #525F7F; padding: 4px 12px; width: 25%;">{{ t_params.env }}</td>
-                <td style="border-bottom: solid 1px #EAEDEF; color: #32325D; padding: 4px 12px; font-weight: 600; width: 25%;">Start time:</td>
-                <td style="border-bottom: solid 1px #EAEDEF; color: #525F7F; padding: 4px 12px; width: 25%;">{{ t_params.start_time }}</td>
+                <td style="border-bottom: solid 1px #EAEDEF; color: #32325D; padding: 4px 12px; font-weight: 600; width: 25%;">Duration:</td>
+                <td style="border-bottom: solid 1px #EAEDEF; color: #525F7F; padding: 4px 12px; width: 25%;">{{ t_params.duration }}</td>
             </tr>
             <tr>
                 <td style="border-bottom: solid 1px #EAEDEF; color: #32325D; padding: 4px 12px; font-weight: 600; width: 25%;">Loops:</td>

--- a/ui_email_notification.py
+++ b/ui_email_notification.py
@@ -200,6 +200,12 @@ class UIEmailNotification(object):
         if self.args.get("missed_thresholds") and missed_thresholds > self.args["missed_thresholds"]:
             status = "FAILED"
             color = RED
+        # Get browser version - try report_info first, then fall back to results_info
+        browser_version = report_info.get('browser_version')
+        if not browser_version or browser_version == 'undefined':
+            browser_version = results_info[0]['browser_version'] if results_info else 'Unknown'
+        print(f"[BROWSER VERSION] Parsed version: {browser_version}")
+        
         t_params = {
             "scenario": report_info['name'],
             "baseline_test_url": baseline_test_url,
@@ -212,8 +218,7 @@ class UIEmailNotification(object):
             "duration": report_info['duration'],
             "env": report_info['environment'],
             "browser": report_info['browser'].capitalize(),
-            "version": report_info['browser_version'],
-            "view_port": "1920x1080",
+            "version": browser_version,
             "loops": report_info["loops"],
             "pages": len(results_info)
         }


### PR DESCRIPTION
- Add parsing support for the browser_version field (to apply this change merge this PR first https://github.com/carrier-io/observer-lighthouse-nodejs/pull/12).
- Display the Baseline field only when a baseline test is seleted.
- Remove the unused 'View port' and 'Reasons' fields.

Before:
<img width="1071" height="517" alt="image" src="https://github.com/user-attachments/assets/217fc14a-92fd-4f49-96e9-fc89107a55e7" />

After:
<img width="1063" height="465" alt="image" src="https://github.com/user-attachments/assets/93e55ba4-ce10-4e47-8a46-529a2277d584" />

