### PR TITLE
Updates for api_email_notifications

### DIFF
--- a/api_email_notification.py
+++ b/api_email_notification.py
@@ -1,0 +1,122 @@
+# Copyright 2019 getcarrier.io
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+from perfreporter.data_manager import DataManager
+from report_builder import ReportBuilder
+from email_notifications import Email
+
+
+GREEN = '#028003'
+YELLOW = '#FFA400'
+RED = '#FF0000'
+GRAY = '#CCCCCC'
+
+STATUS_COLOR = {
+    "success": GREEN,
+    "failed": RED,
+    "finished": GRAY
+}
+
+
+class ApiEmailNotification:
+    """
+    Email notification generator for API performance tests.
+    Handles data collection, report generation, and email formatting for backend tests.
+    """
+
+    def __init__(self, arguments):
+        """
+        Initialize API email notification generator.
+        
+        Args:
+            arguments (dict): Configuration dictionary containing:
+                - galloper_url: URL of the Galloper instance
+                - token: Authentication token
+                - project_id: Project identifier
+                - test: Test name
+                - users: Number of virtual users
+                - notification_type: Type of notification (e.g., 'API', 'Backend')
+                - user_list: Comma-separated list of recipient emails
+                - comparison_metric: Metric to use for baseline comparison (e.g., 'pct95', 'pct90')
+                - env: Environment name
+                - test_type: Type of test (e.g., 'load', 'stress')
+                - performance_degradation_rate: Threshold for performance degradation
+                - missed_threshold_rate: Threshold for missed SLA
+        """
+        self.args = arguments
+        self.data_manager = DataManager(
+            arguments, 
+            arguments["galloper_url"], 
+            arguments["token"],
+            arguments["project_id"]
+        )
+        self.report_builder = ReportBuilder()
+
+    def api_email_notification(self):
+        """
+        Generate email notification for API test results.
+        
+        Orchestrates the entire email generation process:
+        1. Fetches test data from Galloper
+        2. Compares with baseline and thresholds
+        3. Generates email body and charts
+        4. Returns Email object ready to send
+        
+        Returns:
+            Email: Email object containing subject, body, recipients, and charts
+        """
+        # Fetch test data, baseline, and threshold violations
+        tests_data, last_test_data, baseline, violation, compare_with_thresholds = \
+            self.data_manager.get_api_test_info()
+
+        # Generate email body with charts
+        email_body, charts, date = self.report_builder.create_api_email_body(
+            self.args, 
+            tests_data, 
+            last_test_data,
+            baseline,
+            self.args['comparison_metric'],
+            violation, 
+            compare_with_thresholds
+        )
+
+        # Create email subject
+        subject = self._create_email_subject(date)
+
+        # Return Email object
+        return Email(
+            self.args['test'], 
+            subject, 
+            self.args['user_list'], 
+            email_body, 
+            charts, 
+            date
+        )
+
+    def _create_email_subject(self, date):
+        """
+        Create formatted email subject line.
+        
+        Args:
+            date (str): Test execution date
+            
+        Returns:
+            str: Formatted subject line
+        """
+        subject = f"[{self.args['notification_type']}] "
+        subject += f"Test results for \"{self.args['test']}\". "
+        subject += f"Users count: {self.args['users']}. "
+        subject += f"From {date}."
+        return subject

--- a/email_notifications.py
+++ b/email_notifications.py
@@ -3,21 +3,21 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#
+# 
 #     http://www.apache.org/licenses/LICENSE-2.0
-#
+# 
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from perfreporter.data_manager import DataManager
-
-from report_builder import ReportBuilder
-
 
 class Email(object):
+    """
+    Email object to store notification details.
+    Used by both UI and API email notification generators.
+    """
 
     def __init__(self, test_name, subject, users_to, email_body, charts, date):
         self.test_name = test_name
@@ -26,24 +26,3 @@ class Email(object):
         self.charts = charts
         self.date = date
         self.users_to = users_to
-
-
-class ApiEmailNotification:
-    def __init__(self, arguments):
-        self.args = arguments
-        self.data_manager = DataManager(arguments, arguments["galloper_url"], arguments["token"],
-                                        arguments["project_id"])
-        self.report_builder = ReportBuilder()
-
-    def email_notification(self):
-        tests_data, last_test_data, baseline, violation, compare_with_thresholds = self.data_manager.get_api_test_info()
-        email_body, charts, date = self.report_builder.create_api_email_body(self.args, tests_data, last_test_data,
-                                                                             baseline,
-                                                                             self.args['comparison_metric'],
-                                                                             violation, compare_with_thresholds)
-
-        subject = "[" + str(self.args['notification_type']) + "] "
-        subject += "Test results for \"" + str(self.args['test'])
-        subject += "\". Users count: " + str(self.args['users']) + ". From " + str(date) + "."
-
-        return Email(self.args['test'], subject, self.args['user_list'], email_body, charts, date)

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -15,7 +15,7 @@
 import json
 from os import environ
 from email_client import EmailClient
-from email_notifications import ApiEmailNotification
+from api_email_notification import ApiEmailNotification
 from ui_email_notification import UIEmailNotification
 from time import sleep
 from typing import Union
@@ -36,7 +36,7 @@ def lambda_handler(event: Union[list, dict], context):
                         args['notification_type'], args['smtp_password'], args['user_list']]):
                 raise Exception('Some required parameters not passed')
 
-            email = ApiEmailNotification(args).email_notification()
+            email = ApiEmailNotification(args).api_email_notification()
         elif args['notification_type'] == 'ui':
             if not all([args['test_id'], args['report_id']]):
                 raise Exception('test_id and report_id are required for UI reports')

--- a/report_builder.py
+++ b/report_builder.py
@@ -654,7 +654,9 @@ class ReportBuilder:
             "baseline_rt": baseline_rt,
             "baseline_rt_color": baseline_rt_color,
             "threshold_rt": thresholds_rt,
-            "threshold_rt_color": thresholds_rt_color
+            "threshold_rt_color": thresholds_rt_color,
+            "show_baseline_column": baseline_throughput != "N/A" or baseline_error_rate != "N/A" or baseline_rt != "N/A",
+            "show_threshold_column": thresholds_tp_rate != "N/A" or thresholds_error_rate != "N/A" or thresholds_rt != "N/A"
         }
 
     @staticmethod
@@ -716,7 +718,18 @@ class ReportBuilder:
                 hundered = float(exceeded_thresholds[_]['response_time'])
             else:
                 exceeded_thresholds[_]['share'] = int((100 * float(exceeded_thresholds[_]['response_time'])) / hundered)
-        return exceeded_thresholds
+        
+        # Determine column visibility for Request metrics table
+        show_baseline = any(req.get('baseline') != "N/A" for req in exceeded_thresholds)
+        show_threshold = any(req.get('threshold') != "N/A" for req in exceeded_thresholds)
+        show_representation = show_baseline or show_threshold
+        
+        return {
+            "requests": exceeded_thresholds,
+            "show_baseline_column": show_baseline,
+            "show_threshold_column": show_threshold,
+            "show_representation_column": show_representation
+        }
 
     def create_ui_builds_comparison(self, tests):
         comparison, builds_info = [], []

--- a/report_builder.py
+++ b/report_builder.py
@@ -685,6 +685,9 @@ class ReportBuilder:
             if test_params["performance_degradation_rate"] > args["performance_degradation_rate_qg"]:
                 test_params["performance_degradation_rate"] = f'{test_params["performance_degradation_rate"]}%'
                 test_params["baseline_status"] = "failed"
+            elif test_params["performance_degradation_rate"] > 0:
+                test_params["performance_degradation_rate"] = f'{test_params["performance_degradation_rate"]}%'
+                test_params["baseline_status"] = "warning"
             else:
                 test_params["performance_degradation_rate"] = f'{test_params["performance_degradation_rate"]}%'
                 test_params["baseline_status"] = "success"
@@ -695,6 +698,9 @@ class ReportBuilder:
             if test_params["missed_threshold_rate"] > args["missed_thresholds_qg"]:
                 test_params["missed_threshold_rate"] = f'{test_params["missed_threshold_rate"]}%'
                 test_params["threshold_status"] = "failed"
+            elif test_params["missed_threshold_rate"] > 0:
+                test_params["missed_threshold_rate"] = f'{test_params["missed_threshold_rate"]}%'
+                test_params["threshold_status"] = "warning"
             else:
                 test_params["missed_threshold_rate"] = f'{test_params["missed_threshold_rate"]}%'
                 test_params["threshold_status"] = "success"

--- a/report_builder.py
+++ b/report_builder.py
@@ -250,6 +250,7 @@ class ReportBuilder:
         if len(builds) > 1:
             charts.append(self.create_success_rate_chart(builds))
             charts.append(self.create_throughput_chart(builds))
+            charts.append(self.create_response_time_chart(builds))
         return charts
 
     @staticmethod
@@ -305,6 +306,34 @@ class ReportBuilder:
         fp = open('/tmp/throughput.png', 'rb')
         image = MIMEImage(fp.read())
         image.add_header('Content-ID', '<throughput>')
+        fp.close()
+        return image
+
+    @staticmethod
+    def create_response_time_chart(builds):
+        labels, keys, values = [], [], []
+        count = 1
+        for test in builds:
+            labels.append(test['date'])
+            keys.append(test['pct95'])
+            values.append(count)
+            count += 1
+        datapoints = {
+            'title': 'Response Time (pct95)',
+            'label': 'Response Time, ms',
+            'x_axis': 'Test Runs',
+            'y_axis': 'Response Time, ms',
+            'width': 10,
+            'height': 3,
+            'path_to_save': '/tmp/response_time.png',
+            'keys': keys[::-1],
+            'values': values,
+            'labels': labels[::-1]
+        }
+        alerts_linechart(datapoints)
+        fp = open('/tmp/response_time.png', 'rb')
+        image = MIMEImage(fp.read())
+        image.add_header('Content-ID', '<response_time>')
         fp.close()
         return image
 

--- a/templates/backend_email_template.html
+++ b/templates/backend_email_template.html
@@ -153,6 +153,27 @@
         </tbody>
     </table>
 
+    <p style="margin: 24px 0 8px 0; padding: 0 12px; font-weight: 700; color: #525F7F;">Success Rate</p>
+    <div>
+        <div align="center">
+            <img src="cid:success_rate"/>
+        </div>
+    </div>
+
+    <p style="margin: 24px 0 8px 0; padding: 0 12px; font-weight: 700; color: #525F7F;">RPS/TPS Rate</p>
+    <div>
+        <div align="center">
+            <img src="cid:throughput"/>
+        </div>
+    </div>
+
+    <p style="margin: 24px 0 8px 0; padding: 0 12px; font-weight: 700; color: #525F7F;">Response Time (pct95)</p>
+    <div>
+        <div align="center">
+            <img src="cid:response_time"/>
+        </div>
+    </div>
+
     <p style="margin: 24px 0 8px 0; padding: 0 12px; font-weight: 700; color: #525F7F;">Request metrics</p>
     <table style=" width: 100%;">
         <thead>
@@ -239,20 +260,6 @@
         </tbody>
     </table>
 
-
-    <p style="margin: 24px 0 8px 0; padding: 0 12px; font-weight: 700; color: #525F7F;">Success Rate</p>
-    <div>
-        <div align="center">
-            <img src="cid:success_rate"/>
-        </div>
-    </div>
-
-    <p style="margin: 24px 0 8px 0; padding: 0 12px; font-weight: 700; color: #525F7F;">RPS/TPS Rate</p>
-    <div>
-        <div align="center">
-            <img src="cid:throughput"/>
-        </div>
-    </div>
 </div>
 </body>
 </html>

--- a/templates/backend_email_template.html
+++ b/templates/backend_email_template.html
@@ -133,16 +133,22 @@
         </thead>
         <tbody>
         <tr>
-            <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: left; border-bottom: solid 1px #EAEDEF;">Troughput</td>
+            <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: left; border-bottom: solid 1px #EAEDEF;">Throughput, req/sec</td>
             <td style="padding: 8px 12px; font-size: 14px; color: {{ general_metrics.baseline_tp_color }}; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ general_metrics.baseline_tp }}</td>
             <td style="padding: 8px 12px; font-size: 14px; color: {{ general_metrics.threshold_tp_color }}; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ general_metrics.threshold_tp }}</td>
             <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ general_metrics.current_tp }}</td>
         </tr>
         <tr>
-            <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: left; border-bottom: solid 1px #EAEDEF;">Error rate</td>
+            <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: left; border-bottom: solid 1px #EAEDEF;">Error rate, %</td>
             <td style="padding: 8px 12px; font-size: 14px; color: {{ general_metrics.baseline_er_color }}; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ general_metrics.baseline_er }}</td>
             <td style="padding: 8px 12px; font-size: 14px; color: {{ general_metrics.threshold_er_color }}; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ general_metrics.threshold_er }}</td>
             <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ general_metrics.current_er }}</td>
+        </tr>
+        <tr>
+            <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: left; border-bottom: solid 1px #EAEDEF;">Response time (pct95), sec</td>
+            <td style="padding: 8px 12px; font-size: 14px; color: {{ general_metrics.baseline_rt_color }}; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ general_metrics.baseline_rt }}</td>
+            <td style="padding: 8px 12px; font-size: 14px; color: {{ general_metrics.threshold_rt_color }}; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ general_metrics.threshold_rt }}</td>
+            <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ general_metrics.current_rt }}</td>
         </tr>
         </tbody>
     </table>
@@ -212,9 +218,9 @@
             <th style="color: #757F99; padding: 8px 12px; line-height: 16px; font-size: 12px; font-weight: 600; background: #F9FAFF;  border-bottom: solid 1px #EAEDEF; border-top: solid 1px #EAEDEF; text-align: left;">Thrpt, req/sec</th>
             <th style="color: #757F99; padding: 8px 12px; line-height: 16px; font-size: 12px; font-weight: 600; background: #F9FAFF;  border-bottom: solid 1px #EAEDEF; border-top: solid 1px #EAEDEF; text-align: left;">Error, count</th>
             <th style="color: #757F99; padding: 8px 12px; line-height: 16px; font-size: 12px; font-weight: 600; background: #F9FAFF;  border-bottom: solid 1px #EAEDEF; border-top: solid 1px #EAEDEF; text-align: left;">Min, sec</th>
-            <th style="color: #757F99; padding: 8px 12px; line-height: 16px; font-size: 12px; font-weight: 600; background: #F9FAFF;  border-bottom: solid 1px #EAEDEF; border-top: solid 1px #EAEDEF; text-align: left;">Pct95, sec</th>
-            <th style="color: #757F99; padding: 8px 12px; line-height: 16px; font-size: 12px; font-weight: 600; background: #F9FAFF;  border-bottom: solid 1px #EAEDEF; border-top: solid 1px #EAEDEF; text-align: left;">Pct90, sec</th>
             <th style="color: #757F99; padding: 8px 12px; line-height: 16px; font-size: 12px; font-weight: 600; background: #F9FAFF;  border-bottom: solid 1px #EAEDEF; border-top: solid 1px #EAEDEF; text-align: left;">Max, sec</th>
+            <th style="color: #757F99; padding: 8px 12px; line-height: 16px; font-size: 12px; font-weight: 600; background: #F9FAFF;  border-bottom: solid 1px #EAEDEF; border-top: solid 1px #EAEDEF; text-align: left;">Pct90, sec</th>
+            <th style="color: #757F99; padding: 8px 12px; line-height: 16px; font-size: 12px; font-weight: 600; background: #F9FAFF;  border-bottom: solid 1px #EAEDEF; border-top: solid 1px #EAEDEF; text-align: left;">Pct95, sec</th>
         </tr>
         </thead>
         <tbody>

--- a/templates/backend_email_template.html
+++ b/templates/backend_email_template.html
@@ -92,20 +92,20 @@
                 <td style="border-bottom: solid 1px #EAEDEF; color: #525F7F; padding: 4px 12px; width: 25%;"></td>
             </tr>
             <tr>
-                <td style="border-bottom: solid 1px #EAEDEF; color: #32325D; padding: 4px 12px; font-weight: 600; width: 25%;">Duration:</td>
+                <td style="border-bottom: solid 1px #EAEDEF; color: #32325D; padding: 4px 12px; font-weight: 600; width: 25%;">Duration, sec:</td>
                 <td style="border-bottom: solid 1px #EAEDEF; color: #525F7F; padding: 4px 12px; width: 25%;">{{ t_params.duration }}</td>
                 <td style="border-bottom: solid 1px #EAEDEF; color: #32325D; padding: 4px 12px; font-weight: 600; width: 25%;">VUsers:</td>
                 <td style="border-bottom: solid 1px #EAEDEF; color: #525F7F; padding: 4px 12px; width: 25%;">{{ t_params.users }}</td>
             </tr>
             <tr>
                 <td style="border-bottom: solid 1px #EAEDEF; color: #32325D; padding: 4px 12px; font-weight: 600; width: 25%;">Started:</td>
-                <td style="border-bottom: solid 1px #EAEDEF; color: #525F7F; padding: 4px 12px; width: 25%;">{{ t_params.start }}</td>
+                <td style="border-bottom: solid 1px #EAEDEF; color: #525F7F; padding: 4px 12px; width: 25%;">{{ t_params.start }} CET</td>
                 <td style="border-bottom: solid 1px #EAEDEF; color: #32325D; padding: 4px 12px; font-weight: 600; width: 25%;">Environment:</td>
                 <td style="border-bottom: solid 1px #EAEDEF; color: #525F7F; padding: 4px 12px; width: 25%;">{{ t_params.env }}</td>
             </tr>
             <tr>
                 <td style="border-bottom: solid 1px #EAEDEF; color: #32325D; padding: 4px 12px; font-weight: 600; width: 25%;">Ended:</td>
-                <td style="border-bottom: solid 1px #EAEDEF; color: #525F7F; padding: 4px 12px; width: 25%;">{{ t_params.end }}</td>
+                <td style="border-bottom: solid 1px #EAEDEF; color: #525F7F; padding: 4px 12px; width: 25%;">{{ t_params.end }} CET</td>
                 <td style="border-bottom: solid 1px #EAEDEF; color: #32325D; padding: 4px 12px; font-weight: 600; width: 25%;">Test type:</td>
                 <td style="border-bottom: solid 1px #EAEDEF; color: #525F7F; padding: 4px 12px; width: 25%;">{{ t_params.test_type }}</td>
             </tr>

--- a/templates/backend_email_template.html
+++ b/templates/backend_email_template.html
@@ -41,6 +41,7 @@
                     <span>{{ t_params.status }}</span>
                 </div>
             </td>
+            {% if t_params.threshold_status != 'N/A' %}
             <td style="background: #F6F9FC; padding: 4px 12px; border-radius: 4px;">
                 <div style="color: #32325D; font-size: 16px; font-weight: 400;">
                     <span style="margin-right: 10px">SLA failed rate: {{ t_params.missed_threshold_rate }}</span>
@@ -53,11 +54,10 @@
                     {% if t_params.threshold_status == 'failed' %}
                     <span style="color: #F32626; font-size: 16px; font-weight: bold;">✗</span>
                     {% endif %}
-                    {% if t_params.threshold_status == 'N/A' %}
-                    <span style="color: #757F99;">N/A</span>
-                    {% endif %}
                 </div>
             </td>
+            {% endif %}
+            {% if t_params.baseline_status != 'N/A' %}
             <td style="background: #F6F9FC; padding: 4px 12px; border-radius: 4px;">
                 <div style="color: #32325D; font-size: 16px; font-weight: 400;">
                     <span style="margin-right: 10px">Baseline failed rate: {{ t_params.performance_degradation_rate }}</span>
@@ -70,11 +70,9 @@
                     {% if t_params.baseline_status == 'failed' %}
                     <span style="color: #F32626; font-size: 16px; font-weight: bold;">✗</span>
                     {% endif %}
-                    {% if t_params.baseline_status == 'N/A' %}
-                    <span style="color: #757F99;">N/A</span>
-                    {% endif %}
                 </div>
             </td>
+            {% endif %}
         </tr>
     </table>
     {% if t_params.status == 'failed' %}
@@ -126,28 +124,44 @@
         <thead>
         <tr>
             <th style="color: #757F99; padding: 8px 12px; line-height: 16px; font-size: 12px; font-weight: 600; background: #F9FAFF;  border-bottom: solid 1px #EAEDEF; border-top: solid 1px #EAEDEF; text-align: left;">Metric</th>
+            {% if general_metrics.show_baseline_column %}
             <th style="color: #757F99; padding: 8px 12px; line-height: 16px; font-size: 12px; font-weight: 600; background: #F9FAFF;  border-bottom: solid 1px #EAEDEF; border-top: solid 1px #EAEDEF; text-align: left;">Baseline diff</th>
+            {% endif %}
+            {% if general_metrics.show_threshold_column %}
             <th style="color: #757F99; padding: 8px 12px; line-height: 16px; font-size: 12px; font-weight: 600; background: #F9FAFF;  border-bottom: solid 1px #EAEDEF; border-top: solid 1px #EAEDEF; text-align: left;">SLA diff</th>
+            {% endif %}
             <th style="color: #757F99; padding: 8px 12px; line-height: 16px; font-size: 12px; font-weight: 600; background: #F9FAFF;  border-bottom: solid 1px #EAEDEF; border-top: solid 1px #EAEDEF; text-align: left;">Current value</th>
         </tr>
         </thead>
         <tbody>
         <tr>
             <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: left; border-bottom: solid 1px #EAEDEF;">Throughput, req/sec</td>
+            {% if general_metrics.show_baseline_column %}
             <td style="padding: 8px 12px; font-size: 14px; color: {{ general_metrics.baseline_tp_color }}; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ general_metrics.baseline_tp }}</td>
+            {% endif %}
+            {% if general_metrics.show_threshold_column %}
             <td style="padding: 8px 12px; font-size: 14px; color: {{ general_metrics.threshold_tp_color }}; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ general_metrics.threshold_tp }}</td>
+            {% endif %}
             <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ general_metrics.current_tp }}</td>
         </tr>
         <tr>
             <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: left; border-bottom: solid 1px #EAEDEF;">Error rate, %</td>
+            {% if general_metrics.show_baseline_column %}
             <td style="padding: 8px 12px; font-size: 14px; color: {{ general_metrics.baseline_er_color }}; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ general_metrics.baseline_er }}</td>
+            {% endif %}
+            {% if general_metrics.show_threshold_column %}
             <td style="padding: 8px 12px; font-size: 14px; color: {{ general_metrics.threshold_er_color }}; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ general_metrics.threshold_er }}</td>
+            {% endif %}
             <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ general_metrics.current_er }}</td>
         </tr>
         <tr>
             <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: left; border-bottom: solid 1px #EAEDEF;">Response time (pct95), sec</td>
+            {% if general_metrics.show_baseline_column %}
             <td style="padding: 8px 12px; font-size: 14px; color: {{ general_metrics.baseline_rt_color }}; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ general_metrics.baseline_rt }}</td>
+            {% endif %}
+            {% if general_metrics.show_threshold_column %}
             <td style="padding: 8px 12px; font-size: 14px; color: {{ general_metrics.threshold_rt_color }}; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ general_metrics.threshold_rt }}</td>
+            {% endif %}
             <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ general_metrics.current_rt }}</td>
         </tr>
         </tbody>
@@ -179,20 +193,32 @@
         <thead>
         <tr>
             <th style="color: #757F99; padding: 8px 12px; line-height: 16px; font-size: 12px; font-weight: 600; background: #F9FAFF;  border-bottom: solid 1px #EAEDEF; border-top: solid 1px #EAEDEF; text-align: left;">Request name</th>
+            {% if baseline_and_thresholds.show_baseline_column %}
             <th style="color: #757F99; padding: 8px 12px; line-height: 16px; font-size: 12px; font-weight: 600; background: #F9FAFF;  border-bottom: solid 1px #EAEDEF; border-top: solid 1px #EAEDEF; text-align: left;">Baseline diff, sec</th>
+            {% endif %}
+            {% if baseline_and_thresholds.show_threshold_column %}
             <th style="color: #757F99; padding: 8px 12px; line-height: 16px; font-size: 12px; font-weight: 600; background: #F9FAFF;  border-bottom: solid 1px #EAEDEF; border-top: solid 1px #EAEDEF; text-align: left;">Threshold diff, sec</th>
+            {% endif %}
             <th style="color: #757F99; padding: 8px 12px; line-height: 16px; font-size: 12px; font-weight: 600; background: #F9FAFF;  border-bottom: solid 1px #EAEDEF; border-top: solid 1px #EAEDEF; text-align: left;">Current, sec</th>
+            {% if baseline_and_thresholds.show_representation_column %}
             <th style="color: #757F99; padding: 8px 12px; line-height: 16px; font-size: 12px; font-weight: 600; background: #F9FAFF;  border-bottom: solid 1px #EAEDEF; border-top: solid 1px #EAEDEF; text-align: left;">Representation</th>
+            {% endif %}
         </tr>
         </thead>
         <tbody>
-        {% for baseline_result in baseline_and_thresholds %}
+        {% for baseline_result in baseline_and_thresholds.requests %}
         <tr>
             <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ baseline_result.request_name }}</td>
+            {% if baseline_and_thresholds.show_baseline_column %}
             <td style="padding: 8px 12px; font-size: 14px; color: {{ baseline_result.baseline_color }}; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ baseline_result.baseline }}</td>
+            {% endif %}
+            {% if baseline_and_thresholds.show_threshold_column %}
             <td style="padding: 8px 12px; font-size: 14px; color: {{ baseline_result.threshold_color }}; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ baseline_result.threshold }}</td>
+            {% endif %}
             <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ baseline_result.response_time }}</td>
+            {% if baseline_and_thresholds.show_representation_column %}
             <td style="padding: 8px 12px; text-align: left; border-bottom: solid 1px #EAEDEF;"><span style="background: {{ baseline_result.line_color}}; width: 25px; height: 25px; display: inline-block"></span></td>
+            {% endif %}
         </tr>
         {% endfor %}
         </tbody>

--- a/templates/backend_email_template.html
+++ b/templates/backend_email_template.html
@@ -217,7 +217,7 @@
             {% endif %}
             <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: left; border-bottom: solid 1px #EAEDEF;">{{ baseline_result.response_time }}</td>
             {% if baseline_and_thresholds.show_representation_column %}
-            <td style="padding: 8px 12px; text-align: left; border-bottom: solid 1px #EAEDEF;"><span style="background: {{ baseline_result.line_color}}; width: 25px; height: 25px; display: inline-block"></span></td>
+            <td style="padding: 8px 12px; text-align: left; border-bottom: solid 1px #EAEDEF;"><span style="background: {{ baseline_result.line_color}}; width: 25px; height: 25px; display: inline-block;">&nbsp;</span></td>
             {% endif %}
         </tr>
         {% endfor %}

--- a/templates/backend_email_template.html
+++ b/templates/backend_email_template.html
@@ -19,8 +19,11 @@
 <table style="color: #fff; background: #875FFC; padding: 31px; font-size: 16px; font-weight: 600;">
     <tr>
         <td>
-            <img style="color: #ff0000; padding-right: 15px;"
-                    src="data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAABQAAAAYCAYAAAD6S912AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAFdSURBVHgBrVQLccMwDHV2AxAGG4OGQVsE2xAEQiEEQiH0iqBj4A5Bx8BjEAia1JOvyoucpp93p4scy0+WLCmEmSCiOjwDTPTOElkSSxseBZNslCxD9I9bCORGW3sb/bejIWT9NkVUs3QsvTm0dZxFIO5GxHIbIOqn8qX2CdLQ5s0IRB2+qOTMc+BElMJUTni9BIfRsZE0HLKBJVxBPndAFEvO1bFPyN+FCSOBo5YuuRObBglfxykPtcqxqqp1Dks+vN6z/sP6ydgN8BLK+FMyKeIka8mV6sU2nCLMaIz+ec14DuGe5ZvlyPKlXw+/LGvvUZbmQUY9q/u9PYMGSIglcy4RGrfdgbxeRkLzv6Fhe2VE72Z683OnpOL1w6D23P4m6CY7mlZqIIXdwSFJA/a3O9JCwSNRYUKTP+ZiKUIvd6IvTPg97PlEM8I5GV1IN+FWOMTuvLyHWAasX3eAf8SBG7h4AQZrAAAAAElFTkSuQmCC">
+            <img style="color: #ff0000; padding-right: 15px; display: inline-block;"
+                    alt="Logo"
+                    width="20"
+                    height="24"
+                    src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAYCAYAAAD6S912AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAFdSURBVHgBrVQLccMwDHV2AxAGG4OGQVsE2xAEQiEEQiH0iqBj4A5Bx8BjEAia1JOvyoucpp93p4scy0+WLCmEmSCiOjwDTPTOElkSSxseBZNslCxD9I9bCORGW3sb/bejIWT9NkVUs3QsvTm0dZxFIO5GxHIbIOqn8qX2CdLQ5s0IRB2+qOTMc+BElMJUTni9BIfRsZE0HLKBJVxBPndAFEvO1bFPyN+FCSOBo5YuuRObBglfxykPtcqxqqp1Dks+vN6z/sP6ydgN8BLK+FMyKeIka8mV6sU2nCLMaIz+ec14DuGe5ZvlyPKlXw+/LGvvUZbmQUY9q/u9PYMGSIglcy4RGrfdgbxeRkLzv6Fhe2VE72Z683OnpOL1w6D23P4m6CY7mlZqIIXdwSFJA/a3O9JCwSNRYUKTP+ZiKUIvd6IvTPg97PlEM8I5GV1IN+FWOMTuvLyHWAasX3eAf8SBG7h4AQZrAAAAAElFTkSuQmCC">
         </td>
         <td style="margin-left: 8px; font-size: 14px; font-weight: 700; width: 100%">
             Backend Performance Report
@@ -40,29 +43,35 @@
             </td>
             <td style="background: #F6F9FC; padding: 4px 12px; border-radius: 4px;">
                 <div style="color: #32325D; font-size: 16px; font-weight: 400;">
-                    <span style="margin-right: 30px">SLA failed rate: {{ t_params.missed_threshold_rate }}</span>
+                    <span style="margin-right: 10px">SLA failed rate: {{ t_params.missed_threshold_rate }}</span>
                     {% if t_params.threshold_status == 'success' %}
-                    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTIiIHZpZXdCb3g9IjAgMCAxMiAxMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xMS4xNjY3IDZDMTEuMTY2NyA5LjAzNzU3IDguNzA0MzEgMTEuNSA1LjY2Njc1IDExLjVDMi42MjkxOCAxMS41IDAuMTY2NzQ4IDkuMDM3NTcgMC4xNjY3NDggNkMwLjE2Njc0OCAyLjk2MjQzIDIuNjI5MTggMC41IDUuNjY2NzUgMC41QzguNzA0MzEgMC41IDExLjE2NjcgMi45NjI0MyAxMS4xNjY3IDZaTTguNjAyMDUgNS4wNTkwMUM4Ljg0MTc1IDQuODMwMjEgOC44NTA1OCA0LjQ1MDQyIDguNjIxNzggNC4yMTA3MkM4LjM5Mjk3IDMuOTcxMDIgOC4wMTMxOCAzLjk2MjE4IDcuNzczNDggNC4xOTA5OUw0LjgyNjYzIDcuMDAzODZMMy41NjAzOCA1Ljc5NTE2QzMuMzIwNjggNS41NjYzNSAyLjk0MDg5IDUuNTc1MTggMi43MTIwOCA1LjgxNDg4QzIuNDgzMjggNi4wNTQ1OCAyLjQ5MjExIDYuNDM0MzcgMi43MzE4MSA2LjY2MzE4TDQuNDEyMzQgOC4yNjczNEM0LjY0NDIgOC40ODg2NiA1LjAwOTA2IDguNDg4NjYgNS4yNDA5MSA4LjI2NzM1TDguNjAyMDUgNS4wNTkwMVoiIGZpbGw9IiMxMzlBNDEiLz4KPC9zdmc+Cg==">
+                    <span style="color: #139A41; font-size: 16px; font-weight: bold;">✓</span>
+                    {% endif %}
+                    {% if t_params.threshold_status == 'warning' %}
+                    <span style="color: #FFA500; font-size: 16px; font-weight: bold;">⚠</span>
                     {% endif %}
                     {% if t_params.threshold_status == 'failed' %}
-                    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTIiIHZpZXdCb3g9IjAgMCAxMiAxMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik01LjgzMzM3IDExLjVDMi43OTU4MSAxMS41IDAuMzMzMzc0IDkuMDM3NTcgMC4zMzMzNzQgNkMwLjMzMzM3NCAyLjk2MjQzIDIuNzk1ODEgMC41IDUuODMzMzcgMC41QzguODcwOTQgMC41IDExLjMzMzQgMi45NjI0MyAxMS4zMzM0IDZDMTEuMzMzNCA5LjAzNzU3IDguODcwOTQgMTEuNSA1LjgzMzM3IDExLjVaTTguMzMzMzcgNi42QzguNjY0NzQgNi42IDguOTMzMzcgNi4zMzEzNyA4LjkzMzM3IDZDOC45MzMzNyA1LjY2ODYzIDguNjY0NzQgNS40IDguMzMzMzcgNS40TDMuMzMzMzcgNS40QzMuMDAyIDUuNCAyLjczMzM3IDUuNjY4NjMgMi43MzMzNyA2QzIuNzMzMzcgNi4zMzEzNyAzLjAwMiA2LjYgMy4zMzMzNyA2LjZMOC4zMzMzNyA2LjZaIiBmaWxsPSIjRjMyNjI2Ii8+Cjwvc3ZnPgo=">
+                    <span style="color: #F32626; font-size: 16px; font-weight: bold;">✗</span>
                     {% endif %}
                     {% if t_params.threshold_status == 'N/A' %}
-                    N/A
+                    <span style="color: #757F99;">N/A</span>
                     {% endif %}
                 </div>
             </td>
             <td style="background: #F6F9FC; padding: 4px 12px; border-radius: 4px;">
                 <div style="color: #32325D; font-size: 16px; font-weight: 400;">
-                    <span style="margin-right: 30px">Baseline failed rate: {{ t_params.performance_degradation_rate }}</span>
+                    <span style="margin-right: 10px">Baseline failed rate: {{ t_params.performance_degradation_rate }}</span>
                     {% if t_params.baseline_status == 'success' %}
-                    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTIiIHZpZXdCb3g9IjAgMCAxMiAxMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xMS4xNjY3IDZDMTEuMTY2NyA5LjAzNzU3IDguNzA0MzEgMTEuNSA1LjY2Njc1IDExLjVDMi42MjkxOCAxMS41IDAuMTY2NzQ4IDkuMDM3NTcgMC4xNjY3NDggNkMwLjE2Njc0OCAyLjk2MjQzIDIuNjI5MTggMC41IDUuNjY2NzUgMC41QzguNzA0MzEgMC41IDExLjE2NjcgMi45NjI0MyAxMS4xNjY3IDZaTTguNjAyMDUgNS4wNTkwMUM4Ljg0MTc1IDQuODMwMjEgOC44NTA1OCA0LjQ1MDQyIDguNjIxNzggNC4yMTA3MkM4LjM5Mjk3IDMuOTcxMDIgOC4wMTMxOCAzLjk2MjE4IDcuNzczNDggNC4xOTA5OUw0LjgyNjYzIDcuMDAzODZMMy41NjAzOCA1Ljc5NTE2QzMuMzIwNjggNS41NjYzNSAyLjk0MDg5IDUuNTc1MTggMi43MTIwOCA1LjgxNDg4QzIuNDgzMjggNi4wNTQ1OCAyLjQ5MjExIDYuNDM0MzcgMi43MzE4MSA2LjY2MzE4TDQuNDEyMzQgOC4yNjczNEM0LjY0NDIgOC40ODg2NiA1LjAwOTA2IDguNDg4NjYgNS4yNDA5MSA4LjI2NzM1TDguNjAyMDUgNS4wNTkwMVoiIGZpbGw9IiMxMzlBNDEiLz4KPC9zdmc+Cg==">
+                    <span style="color: #139A41; font-size: 16px; font-weight: bold;">✓</span>
+                    {% endif %}
+                    {% if t_params.baseline_status == 'warning' %}
+                    <span style="color: #FFA500; font-size: 16px; font-weight: bold;">⚠</span>
                     {% endif %}
                     {% if t_params.baseline_status == 'failed' %}
-                    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTIiIHZpZXdCb3g9IjAgMCAxMiAxMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik01LjgzMzM3IDExLjVDMi43OTU4MSAxMS41IDAuMzMzMzc0IDkuMDM3NTcgMC4zMzMzNzQgNkMwLjMzMzM3NCAyLjk2MjQzIDIuNzk1ODEgMC41IDUuODMzMzcgMC41QzguODcwOTQgMC41IDExLjMzMzQgMi45NjI0MyAxMS4zMzM0IDZDMTEuMzMzNCA5LjAzNzU3IDguODcwOTQgMTEuNSA1LjgzMzM3IDExLjVaTTguMzMzMzcgNi42QzguNjY0NzQgNi42IDguOTMzMzcgNi4zMzEzNyA4LjkzMzM3IDZDOC45MzMzNyA1LjY2ODYzIDguNjY0NzQgNS40IDguMzMzMzcgNS40TDMuMzMzMzcgNS40QzMuMDAyIDUuNCAyLjczMzM3IDUuNjY4NjMgMi43MzMzNyA2QzIuNzMzMzcgNi4zMzEzNyAzLjAwMiA2LjYgMy4zMzMzNyA2LjZMOC4zMzMzNyA2LjZaIiBmaWxsPSIjRjMyNjI2Ii8+Cjwvc3ZnPgo=">
+                    <span style="color: #F32626; font-size: 16px; font-weight: bold;">✗</span>
                     {% endif %}
                     {% if t_params.baseline_status == 'N/A' %}
-                    N/A
+                    <span style="color: #757F99;">N/A</span>
                     {% endif %}
                 </div>
             </td>
@@ -74,8 +83,7 @@
         <ul style="padding-left: 25px;">
         {% for reason in t_params.reasons_to_fail_report %}
             <li style="list-style: none">
-                <span style="margin-right: 5px;"><img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTIiIHZpZXdCb3g9IjAgMCAxMiAxMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik01LjgzMzM3IDExLjVDMi43OTU4MSAxMS41IDAuMzMzMzc0IDkuMDM3NTcgMC4zMzMzNzQgNkMwLjMzMzM3NCAyLjk2MjQzIDIuNzk1ODEgMC41IDUuODMzMzcgMC41QzguODcwOTQgMC41IDExLjMzMzQgMi45NjI0MyAxMS4zMzM0IDZDMTEuMzMzNCA5LjAzNzU3IDguODcwOTQgMTEuNSA1LjgzMzM3IDExLjVaTTguMzMzMzcgNi42QzguNjY0NzQgNi42IDguOTMzMzcgNi4zMzEzNyA4LjkzMzM3IDZDOC45MzMzNyA1LjY2ODYzIDguNjY0NzQgNS40IDguMzMzMzcgNS40TDMuMzMzMzcgNS40QzMuMDAyIDUuNCAyLjczMzM3IDUuNjY4NjMgMi43MzMzNyA2QzIuNzMzMzcgNi4zMzEzNyAzLjAwMiA2LjYgMy4zMzMzNyA2LjZMOC4zMzMzNyA2LjZaIiBmaWxsPSIjRjMyNjI2Ii8+Cjwvc3ZnPgo=">
-                </span>{{ reason }}
+                <span style="color: #F32626; font-size: 14px; font-weight: bold; margin-right: 5px;">✗</span>{{ reason }}
             </li>
         {% endfor %}
         </ul>


### PR DESCRIPTION
1.	A separate api_email_notification.py file has been created; dependencies have been updated.
2.	start_time and end_time has been updated (now they are taken from Galloper API endpoints for reports).
3.	Time has been changed from UTC to CET, CET tags added.
 
Was
 
<img width="1236" height="634" alt="image" src="https://github.com/user-attachments/assets/3cb1671a-fd6e-444d-84d9-153e63c20066" />
 
Now
 
<img width="1374" height="634" alt="image" src="https://github.com/user-attachments/assets/1ec5ba51-5937-4c23-abd3-d4d1fc0f888d" />
 
4.	Warning status added; Unicode characters used instead of SVG images
 
Was
 
<img width="1153" height="559" alt="image" src="https://github.com/user-attachments/assets/517a0f68-4980-4290-bc50-09ce491ad1db" />
 
Now
 
<img width="1119" height="659" alt="image" src="https://github.com/user-attachments/assets/2c42000f-ba5d-4aca-bb70-914d553781c6" />
 
5.	The max and pct95 columns in the Results summary table have been swapped. Added Response time to General metrics
 
Was
 
<img width="1388" height="589" alt="image" src="https://github.com/user-attachments/assets/dca8a7c9-32e5-49eb-8524-32bd48b5e611" />
 
Now
 
<img width="1390" height="609" alt="image" src="https://github.com/user-attachments/assets/8ec0355f-12dd-4de9-8021-930979834acb" /> 
 
6.	Added the create_response_time_chart method. Added the display of the Response Time chart. The display of graphs was moved immediately after General Metrics.
 
Was
<img width="1003" height="701" alt="image" src="https://github.com/user-attachments/assets/63d583fc-a940-49d3-8be6-42369018adc4" />
 
Now
 
<img width="1006" height="781" alt="image" src="https://github.com/user-attachments/assets/40e0ab2f-16f9-4fb4-b729-29453c9d71c5" />
 
7.	The date image for tables and graphs has been changed: for the Comparison with latest builds table, time acquisition has been changed, and the date_img variable has been added to correctly display time on graphs.
 
Was
 
<img width="1183" height="436" alt="image" src="https://github.com/user-attachments/assets/73a25af1-1a1c-44a4-836b-1917b03c03c8" />
 
Now
 
<img width="1183" height="790" alt="image" src="https://github.com/user-attachments/assets/399bd135-cd8a-42d3-af5c-9f3525b69880" />
 
8.	Hiding the Baseline diff and Threshold diff columns in cases where no values are set for them.
 
Was
 
<img width="995" height="716" alt="image" src="https://github.com/user-attachments/assets/09558387-f0f2-48cb-96bc-d2d159ce90eb" />
 
Now

<img width="1183" height="790" alt="image" src="https://github.com/user-attachments/assets/afba442c-e5fc-4360-b547-da59fe923966" /> 
 
9.	Fixed inline_block (Representation column) as it can't be displayed without any content.

Was

<img width="1403" height="490" alt="image" src="https://github.com/user-attachments/assets/df4ae393-baf0-4f2e-b42f-ccd9dc4ebff2" /> 
 
Now
 
<img width="1026" height="475" alt="image" src="https://github.com/user-attachments/assets/7da2c4fe-60cc-480e-a106-e51fa7b1858a" />
 
10.	zip archive has been updated
 

