### PR TITLE
update ui email notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# Working With performance_email_notification
+
+This repo provides an AWS Lambda-style entrypoint that generates and sends
+HTML performance test email notifications for API (backend) and UI tests using
+data from a Galloper instance.
+
+## Quick map
+- Entrypoint: `lambda_function.py` (`lambda_handler`)
+- API notifications: `api_email_notification.py` -> `report_builder.py`
+- UI notifications: `ui_email_notification.py` -> `thresholds_comparison.py`
+- Email transport: `email_client.py`
+- Charts: `chart_generator.py`
+- Templates: `templates/backend_email_template.html`, `templates/ui_email_template.html`
+- Docs for logic: `THRESHOLD_MATCHING_LOGIC.md`, `DEVIATION_LOGIC.md`
+- Tests: `tests/test_lamda.py` (typo in filename, but runnable with pytest)
+
+## Execution flow (Lambda)
+1. `lambda_function.lambda_handler(event, context)` parses the event into `args`.
+2. `notification_type` decides the flow:
+   - `api`: builds backend report and charts, then sends email.
+   - `ui`: builds UI report and charts, then sends email.
+3. `email_client.EmailClient.send_email` sends per-recipient emails via SMTP.
+
+## Event/args contract (important)
+The Lambda expects a JSON payload (direct event or `{"body": "...json..."}`).
+
+Common keys used by `lambda_function.py`:
+- `notification_type`: `api` or `ui`
+- `smtp_host`, `smtp_port`, `smtp_user`, `smtp_password`, `smtp_sender`
+- `user_list`: list of recipients (supports Slack-style `<mailto:...|...>` format)
+- `galloper_url`, `token`, `project_id`
+- `users`, `test`, `env`, `test_limit`, `comparison_metric`
+
+API-specific keys:
+- `test_type` (e.g., load, stress)
+- `quality_gate_config` (baseline/SLA logic)
+- `performance_degradation_rate`, `missed_threshold_rate`
+- `reasons_to_fail_report` (fallback for comparison metric parsing)
+
+UI-specific keys:
+- `test_id`, `report_id`
+- `test_suite` (mapped into `test_type`)
+- `smtp_password` is expected to be a dict for UI: `{"value": "..."}`
+
+Note: README mentions `smpt_*` keys, but the code uses `smtp_*` keys. Align new
+payloads with code unless you plan to update the parser.
+
+## Dependencies and runtime
+- Python dependencies in `requirements.txt`
+  - `perfreporter` (from GitHub) provides `DataManager` for Galloper data.
+- Charts are rendered with `matplotlib` using `Agg` backend (headless).
+
+## Templates and rendering
+- Email bodies are Jinja2 templates in `templates/`.
+- API path uses `ReportBuilder.create_api_email_body` to assemble the context
+  and charts, then renders `templates/backend_email_template.html`.
+- UI path uses `UIEmailNotification` to render `templates/ui_email_template.html`.
+- Charts are saved to disk and attached as inline images (MIME).
+
+## Threshold and baseline logic
+- API thresholds/baseline matching is documented in `THRESHOLD_MATCHING_LOGIC.md`
+  and `DEVIATION_LOGIC.md`.
+- UI thresholds are fetched via Galloper API in `thresholds_comparison.py`.
+- Metric selection for API comparisons can auto-adjust based on SLA settings;
+  see `ReportBuilder.create_api_email_body`.
+
+## Common pitfalls to check when debugging
+- SMTP config: `smtp_password` type differs between API and UI flows.
+- Event shapes: API expects `test_type`, UI expects `test_id` + `report_id`.
+- README vs code param names: `smpt_*` in README is outdated.
+- Galloper auth: `galloper_url`, `token`, `project_id` must be valid.
+- Comparison metric: auto-detected from `quality_gate_config` when missing.
+
+## Local dev tips
+- Quick call to the handler:
+  ```python
+  from lambda_function import lambda_handler
+  lambda_handler({"notification_type": "ui", "test_id": "...", "report_id": 123}, {})
+  ```
+- Run tests:
+  ```bash
+  pytest -q
+  ```
+
+## When adding features
+- Keep event parsing in `lambda_function.py` the single source of truth.
+- Update README if you change payload names or required fields.
+- Adjust templates and `ReportBuilder`/`UIEmailNotification` together so
+  context keys stay in sync.

--- a/templates/ui_email_template.html
+++ b/templates/ui_email_template.html
@@ -22,7 +22,7 @@
 </head>
 
     {% macro display_value(value) -%}
-        {% if "Requires newer" in value|string %}<span class="outdated">{{ value|replace("\n", "<br>")|safe }}</span>{% else %}{{ value }}{% endif %}
+        {% if "No data" in value|string %}<span class="outdated">{{ value|replace("\n", "<br>")|safe }}</span>{% else %}{{ value }}{% endif %}
     {%- endmacro %}<body>
 <table style="color: #fff; background: #875FFC; padding: 31px; font-size: 16px; font-weight: 600;">
     <tr>
@@ -69,21 +69,6 @@
             {% endif %}
         </tr>
     </table>
-
-    {% if t_params.total_thresholds == 0 %}
-    <div style="margin: 24px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #2196F3; border-radius: 4px;">
-        <p style="margin: 0; color: #1565C0; font-size: 14px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> Please set the thresholds to compare the metrics against them.
-        </p>
-    </div>
-    {% endif %}
-    {% if not baseline_comparison_actions and not baseline_comparison_pages %}
-    <div style="margin: 24px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #2196F3; border-radius: 4px;">
-        <p style="margin: 0; color: #1565C0; font-size: 14px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> Please select a baseline test so the metrics can be compared against it.
-        </p>
-    </div>
-    {% endif %}
 
     <div style="margin-top: 24px;">
         <table style="width: 100%;">
@@ -145,11 +130,11 @@
         <tr>
             <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: left; border-bottom: solid 1px #EAEDEF;"><a href={{ result.report }}>{{ result.date }}</a></td>
             <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: right; border-bottom: solid 1px #EAEDEF;">{{ display_value(result.ttfb) }}</td>
-            <td style="padding: 8px 12px; font-size: 14px; text-align: right; border-bottom: solid 1px #EAEDEF; {% if loop.first %}color: #32325D;{% elif "Requires newer" in page_comparison[0].ttfb|string or "Requires newer" in result.ttfb|string %}color: #32325D;{% else %}{% set diff = result.ttfb|float - page_comparison[0].ttfb|float %}{% if diff <= 0 %}color: #27AE60;{% else %}color: #E74C3C;{% endif %}{% endif %}">{% if loop.first %}—{% elif "Requires newer" in page_comparison[0].ttfb|string or "Requires newer" in result.ttfb|string %}{{ display_value(result.ttfb) }}{% else %}{% set diff = result.ttfb|float - page_comparison[0].ttfb|float %}{% if diff > 0 %}+{% endif %}{{ "%.2f"|format(diff) }}{% endif %}</td>
+            <td style="padding: 8px 12px; font-size: 14px; text-align: right; border-bottom: solid 1px #EAEDEF; {% if loop.first %}color: #32325D;{% elif "No data" in page_comparison[0].ttfb|string or "No data" in result.ttfb|string %}color: #32325D;{% else %}{% set diff = result.ttfb|float - page_comparison[0].ttfb|float %}{% if diff <= 0 %}color: #27AE60;{% else %}color: #E74C3C;{% endif %}{% endif %}">{% if loop.first %}—{% elif "No data" in page_comparison[0].ttfb|string or "No data" in result.ttfb|string %}{{ display_value(result.ttfb) }}{% else %}{% set diff = result.ttfb|float - page_comparison[0].ttfb|float %}{% if diff > 0 %}+{% endif %}{{ "%.2f"|format(diff) }}{% endif %}</td>
             <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: right; border-bottom: solid 1px #EAEDEF;">{{ display_value(result.tbt) }}</td>
-            <td style="padding: 8px 12px; font-size: 14px; text-align: right; border-bottom: solid 1px #EAEDEF; {% if loop.first %}color: #32325D;{% elif "Requires newer" in page_comparison[0].tbt|string or "Requires newer" in result.tbt|string %}color: #32325D;{% else %}{% set diff = result.tbt|float - page_comparison[0].tbt|float %}{% if diff <= 0 %}color: #27AE60;{% else %}color: #E74C3C;{% endif %}{% endif %}">{% if loop.first %}—{% elif "Requires newer" in page_comparison[0].tbt|string or "Requires newer" in result.tbt|string %}{{ display_value(result.tbt) }}{% else %}{% set diff = result.tbt|float - page_comparison[0].tbt|float %}{% if diff > 0 %}+{% endif %}{{ "%.2f"|format(diff) }}{% endif %}</td>
+            <td style="padding: 8px 12px; font-size: 14px; text-align: right; border-bottom: solid 1px #EAEDEF; {% if loop.first %}color: #32325D;{% elif "No data" in page_comparison[0].tbt|string or "No data" in result.tbt|string %}color: #32325D;{% else %}{% set diff = result.tbt|float - page_comparison[0].tbt|float %}{% if diff <= 0 %}color: #27AE60;{% else %}color: #E74C3C;{% endif %}{% endif %}">{% if loop.first %}—{% elif "No data" in page_comparison[0].tbt|string or "No data" in result.tbt|string %}{{ display_value(result.tbt) }}{% else %}{% set diff = result.tbt|float - page_comparison[0].tbt|float %}{% if diff > 0 %}+{% endif %}{{ "%.2f"|format(diff) }}{% endif %}</td>
             <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: right; border-bottom: solid 1px #EAEDEF;">{{ display_value(result.lcp) }}</td>
-            <td style="padding: 8px 12px; font-size: 14px; text-align: right; border-bottom: solid 1px #EAEDEF; {% if loop.first %}color: #32325D;{% elif "Requires newer" in page_comparison[0].lcp|string or "Requires newer" in result.lcp|string %}color: #32325D;{% else %}{% set diff = result.lcp|float - page_comparison[0].lcp|float %}{% if diff <= 0 %}color: #27AE60;{% else %}color: #E74C3C;{% endif %}{% endif %}">{% if loop.first %}—{% elif "Requires newer" in page_comparison[0].lcp|string or "Requires newer" in result.lcp|string %}{{ display_value(result.lcp) }}{% else %}{% set diff = result.lcp|float - page_comparison[0].lcp|float %}{% if diff > 0 %}+{% endif %}{{ "%.2f"|format(diff) }}{% endif %}</td>
+            <td style="padding: 8px 12px; font-size: 14px; text-align: right; border-bottom: solid 1px #EAEDEF; {% if loop.first %}color: #32325D;{% elif "No data" in page_comparison[0].lcp|string or "No data" in result.lcp|string %}color: #32325D;{% else %}{% set diff = result.lcp|float - page_comparison[0].lcp|float %}{% if diff <= 0 %}color: #27AE60;{% else %}color: #E74C3C;{% endif %}{% endif %}">{% if loop.first %}—{% elif "No data" in page_comparison[0].lcp|string or "No data" in result.lcp|string %}{{ display_value(result.lcp) }}{% else %}{% set diff = result.lcp|float - page_comparison[0].lcp|float %}{% if diff > 0 %}+{% endif %}{{ "%.2f"|format(diff) }}{% endif %}</td>
         </tr>
                 {% endfor %}
         </tbody>
@@ -185,11 +170,11 @@
         <tr>
             <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: left; border-bottom: solid 1px #EAEDEF;"><a href={{ result.report }}>{{ result.date }}</a></td>
             <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: right; border-bottom: solid 1px #EAEDEF;">{{ display_value(result.cls) }}</td>
-            <td style="padding: 8px 12px; font-size: 14px; text-align: right; border-bottom: solid 1px #EAEDEF; {% if loop.first %}color: #32325D;{% elif "Requires newer" in action_comparison[0].cls|string or "Requires newer" in result.cls|string %}color: #32325D;{% else %}{% set diff = result.cls|float - action_comparison[0].cls|float %}{% if diff <= 0 %}color: #27AE60;{% else %}color: #E74C3C;{% endif %}{% endif %}">{% if loop.first %}—{% elif "Requires newer" in action_comparison[0].cls|string or "Requires newer" in result.cls|string %}{{ display_value(result.cls) }}{% else %}{% set diff = result.cls|float - action_comparison[0].cls|float %}{% if diff > 0 %}+{% endif %}{{ "%.2f"|format(diff) }}{% endif %}</td>
+            <td style="padding: 8px 12px; font-size: 14px; text-align: right; border-bottom: solid 1px #EAEDEF; {% if loop.first %}color: #32325D;{% elif "No data" in action_comparison[0].cls|string or "No data" in result.cls|string %}color: #32325D;{% else %}{% set diff = result.cls|float - action_comparison[0].cls|float %}{% if diff <= 0 %}color: #27AE60;{% else %}color: #E74C3C;{% endif %}{% endif %}">{% if loop.first %}—{% elif "No data" in action_comparison[0].cls|string or "No data" in result.cls|string %}{{ display_value(result.cls) }}{% else %}{% set diff = result.cls|float - action_comparison[0].cls|float %}{% if diff > 0 %}+{% endif %}{{ "%.2f"|format(diff) }}{% endif %}</td>
             <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: right; border-bottom: solid 1px #EAEDEF;">{{ display_value(result.tbt) }}</td>
-            <td style="padding: 8px 12px; font-size: 14px; text-align: right; border-bottom: solid 1px #EAEDEF; {% if loop.first %}color: #32325D;{% elif "Requires newer" in action_comparison[0].tbt|string or "Requires newer" in result.tbt|string %}color: #32325D;{% else %}{% set diff = result.tbt|float - action_comparison[0].tbt|float %}{% if diff <= 0 %}color: #27AE60;{% else %}color: #E74C3C;{% endif %}{% endif %}">{% if loop.first %}—{% elif "Requires newer" in action_comparison[0].tbt|string or "Requires newer" in result.tbt|string %}{{ display_value(result.tbt) }}{% else %}{% set diff = result.tbt|float - action_comparison[0].tbt|float %}{% if diff > 0 %}+{% endif %}{{ "%.2f"|format(diff) }}{% endif %}</td>
+            <td style="padding: 8px 12px; font-size: 14px; text-align: right; border-bottom: solid 1px #EAEDEF; {% if loop.first %}color: #32325D;{% elif "No data" in action_comparison[0].tbt|string or "No data" in result.tbt|string %}color: #32325D;{% else %}{% set diff = result.tbt|float - action_comparison[0].tbt|float %}{% if diff <= 0 %}color: #27AE60;{% else %}color: #E74C3C;{% endif %}{% endif %}">{% if loop.first %}—{% elif "No data" in action_comparison[0].tbt|string or "No data" in result.tbt|string %}{{ display_value(result.tbt) }}{% else %}{% set diff = result.tbt|float - action_comparison[0].tbt|float %}{% if diff > 0 %}+{% endif %}{{ "%.2f"|format(diff) }}{% endif %}</td>
             <td style="padding: 8px 12px; font-size: 14px; color: #32325D; text-align: right; border-bottom: solid 1px #EAEDEF;">{{ display_value(result.inp) }}</td>
-            <td style="padding: 8px 12px; font-size: 14px; text-align: right; border-bottom: solid 1px #EAEDEF; {% if loop.first %}color: #32325D;{% elif "Requires newer" in action_comparison[0].inp|string or "Requires newer" in result.inp|string %}color: #32325D;{% else %}{% set diff = result.inp|float - action_comparison[0].inp|float %}{% if diff <= 0 %}color: #27AE60;{% else %}color: #E74C3C;{% endif %}{% endif %}">{% if loop.first %}—{% elif "Requires newer" in action_comparison[0].inp|string or "Requires newer" in result.inp|string %}{{ display_value(result.inp) }}{% else %}{% set diff = result.inp|float - action_comparison[0].inp|float %}{% if diff > 0 %}+{% endif %}{{ "%.2f"|format(diff) }}{% endif %}</td>
+            <td style="padding: 8px 12px; font-size: 14px; text-align: right; border-bottom: solid 1px #EAEDEF; {% if loop.first %}color: #32325D;{% elif "No data" in action_comparison[0].inp|string or "No data" in result.inp|string %}color: #32325D;{% else %}{% set diff = result.inp|float - action_comparison[0].inp|float %}{% if diff <= 0 %}color: #27AE60;{% else %}color: #E74C3C;{% endif %}{% endif %}">{% if loop.first %}—{% elif "No data" in action_comparison[0].inp|string or "No data" in result.inp|string %}{{ display_value(result.inp) }}{% else %}{% set diff = result.inp|float - action_comparison[0].inp|float %}{% if diff > 0 %}+{% endif %}{{ "%.2f"|format(diff) }}{% endif %}</td>
         </tr>
                 {% endfor %}
         </tbody>
@@ -344,6 +329,20 @@
         </tbody>
     </table>
         {% endif %}
+    {% if t_params.total_thresholds == 0 %}
+    <div style="margin: 24px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #2196F3; border-radius: 4px;">
+        <p style="margin: 0; color: #1565C0; font-size: 14px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> Please set the thresholds to compare the metrics against them.
+        </p>
+    </div>
+    {% endif %}
+    {% if not baseline_comparison_actions and not baseline_comparison_pages %}
+    <div style="margin: 24px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #2196F3; border-radius: 4px;">
+        <p style="margin: 0; color: #1565C0; font-size: 14px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> Please select a baseline test so the metrics can be compared against it.
+        </p>
+    </div>
+    {% endif %}
 </div>
 </body>
 </html>

--- a/ui_email_notification.py
+++ b/ui_email_notification.py
@@ -28,12 +28,12 @@ class UIEmailNotification:
     def _safe_metric_conversion(self, value, metric_name, is_cls=False, divisor=1000):
         """Convert metric value safely with error handling."""
         try:
-            if value == "Requires newer\nLighthouse version":
+            if value == "No data":
                 return value
             return round(float(value) / divisor, 2) if not is_cls else round(float(value), 2)
         except (ValueError, TypeError) as e:
             print(f"[WARNING] Invalid value for metric '{metric_name}': {e}")
-            return "Requires newer\nLighthouse version"
+            return "No data"
 
     def _aggregate_metrics(self, test_data, metric_names, is_cls_metric=False):
         """Aggregate metrics from test data with safe averaging."""
@@ -51,25 +51,27 @@ class UIEmailNotification:
                     else:
                         aggregated[metric] = round((sum(_arr) / len(_arr)) / 1000, 2)
                 else:
-                    aggregated[metric] = "Requires newer\nLighthouse version"
+                    aggregated[metric] = "No data"
             except (KeyError, ValueError, TypeError) as e:
                 print(f"[WARNING] Missing or invalid metric '{metric}': {e}")
-                aggregated[metric] = "Requires newer\nLighthouse version"
+                aggregated[metric] = "No data"
         return aggregated
 
     def _build_comparison_data(self, last_reports, tests_data):
         """Build page and action comparison data from test results."""
         page_comparison, action_comparison = [], []
-        
+
         for index, test in enumerate(tests_data):
             page_metrics = self._aggregate_metrics(test["pages"], ["load_time", "tbt", "fcp", "lcp", "ttfb"])
             page_metrics["date"] = self.convert_short_date_to_cet(last_reports[index]["start_time"], '%d-%b %H:%M')
-            page_metrics["report"] = f"{self.gelloper_url}/-/performance/ui/results?result_id={last_reports[index]['id']}"
+            page_metrics[
+                "report"] = f"{self.gelloper_url}/-/performance/ui/results?result_id={last_reports[index]['id']}"
             page_comparison.append(page_metrics)
 
             action_metrics = self._aggregate_metrics(test["actions"], ["cls", "tbt", "inp"])
             action_metrics["date"] = self.convert_short_date_to_cet(last_reports[index]["start_time"], '%d-%b %H:%M')
-            action_metrics["report"] = f"{self.gelloper_url}/-/performance/ui/results?result_id={last_reports[index]['id']}"
+            action_metrics[
+                "report"] = f"{self.gelloper_url}/-/performance/ui/results?result_id={last_reports[index]['id']}"
             action_comparison.append(action_metrics)
 
         return page_comparison, action_comparison
@@ -81,23 +83,23 @@ class UIEmailNotification:
         for result in results_info:
             identifier = result.get('identifier', result.get('name'))
             result_type = result.get('type', 'page')
-            
+
             applicable_thresholds = (
-                thresholds_grouped.get('every', []) + 
-                thresholds_grouped.get(identifier, []) +
-                thresholds_grouped.get('all', [])
+                    thresholds_grouped.get('every', []) +
+                    thresholds_grouped.get(identifier, []) +
+                    thresholds_grouped.get('all', [])
             )
-            
+
             metrics_to_check = ["load_time", "dom", "fcp", "lcp", "cls", "tbt", "ttfb", "fvc", "lvc"] \
                 if result_type == "page" else ["cls", "tbt", "inp"]
-            
+
             for metric_short in metrics_to_check:
                 if metric_short not in result:
                     continue
-                    
+
                 metric_full = thresholds_processor.METRICS_MAPPER.get(metric_short, metric_short)
                 metric_thresholds = [th for th in applicable_thresholds if th.get('target') == metric_full]
-                
+
                 if not metric_thresholds:
                     result[f"{metric_short}_color"] = ""
                     continue
@@ -109,18 +111,20 @@ class UIEmailNotification:
                     threshold_value = threshold.get('value', 0)
                     if metric_short != "cls":
                         threshold_value *= 1000
-                    
+
                     comparison = threshold.get('comparison', 'lte')
                     total_checked += 1
-                    
+
                     if thresholds_processor.is_threshold_failed(actual_value, comparison, threshold_value):
                         is_failed = True
                         failed_count += 1
-                        print(f"[THRESHOLD VIOLATION] {result.get('name')} - {metric_short}: {actual_value} violates {comparison} {threshold_value}")
+                        print(
+                            f"[THRESHOLD VIOLATION] {result.get('name')} - {metric_short}: {actual_value} violates {comparison} {threshold_value}")
                         break
                     else:
-                        print(f"[THRESHOLD PASS] {result.get('name')} - {metric_short}: {actual_value} complies with {comparison} {threshold_value}")
-                
+                        print(
+                            f"[THRESHOLD PASS] {result.get('name')} - {metric_short}: {actual_value} complies with {comparison} {threshold_value}")
+
                 result[f"{metric_short}_color"] = f"color: {RED};" if is_failed else f"color: {GREEN};"
 
         missed_pct = round(float(failed_count / total_checked) * 100, 2) if total_checked > 0 else 0
@@ -131,26 +135,26 @@ class UIEmailNotification:
         """Convert result units from milliseconds to seconds."""
         for result in results_info:
             result["report"] = f"{self.gelloper_url}{result['report'][0]}"
-            
+
             for metric in ["load_time", "dom", "fcp", "lcp", "tbt", "ttfb", "fvc", "lvc", "inp"]:
                 if metric in result:
                     result[metric] = self._safe_metric_conversion(result[metric], metric)
                 else:
-                    result[metric] = "Requires newer\nLighthouse version"
-            
+                    result[metric] = "No data"
+
             if "cls" in result:
                 result["cls"] = self._safe_metric_conversion(result["cls"], "cls", is_cls=True, divisor=1)
             else:
-                result["cls"] = "Requires newer\nLighthouse version"
+                result["cls"] = "No data"
 
     def _process_baseline_comparison(self, baseline_info, results_info, baseline_report_info):
         """Process baseline comparison and calculate degradation rate."""
         baseline_results = self._aggregate_results_by_identifier(baseline_info, is_baseline=True)
         current_results = self._aggregate_results_by_identifier(results_info, is_baseline=False)
-        
+
         aggregated_baseline = self._finalize_aggregated_results(baseline_results)
         aggregated_current = self._finalize_aggregated_results(current_results)
-        
+
         baseline_comparison_pages, baseline_comparison_actions = [], []
         count, failed = 0, 0
         degradation_rate_setting = self.args.get("performance_degradation_rate")
@@ -168,30 +172,47 @@ class UIEmailNotification:
 
             comparison = {"name": current["name"]}
             metrics = ["lcp", "tbt", "ttfb"] if current["type"] == "page" else ["tbt", "cls", "inp"]
-            
+            any_failed = False
+            any_checked = False
+
             for metric in metrics:
                 comparison[metric] = current[metric]
                 comparison[f"{metric}_baseline"] = baseline[metric]
-                
-                if current[metric] == "Requires newer\nLighthouse version" or baseline[metric] == "Requires newer\nLighthouse version":
-                    comparison[f"{metric}_diff"] = "Requires newer\nLighthouse version"
+
+                if current[metric] == "No data" or baseline[
+                    metric] == "No data":
+                    comparison[f"{metric}_diff"] = "No data"
                     comparison[f"{metric}_diff_color"] = ""
                 else:
-                    count += 1
+                    any_checked = True
                     baseline_with_deviation = float(baseline[metric]) * (1 + (degradation_rate_setting / 100))
                     baseline_with_deviation = round(baseline_with_deviation, 2)
                     comparison[f"{metric}_baseline"] = baseline_with_deviation
                     diff = round(float(current[metric]) - baseline_with_deviation, 2)
                     if diff > 0:
-                        failed += 1
+                        any_failed = True
                         comparison[f"{metric}_diff"] = f'+{diff}'
                         comparison[f"{metric}_diff_color"] = "color:red;"
                     else:
                         comparison[f"{metric}_diff"] = diff
                         comparison[f"{metric}_diff_color"] = "color:green;"
-            
+
+            if any_checked:
+                count += 1
+                if any_failed:
+                    failed += 1
+            comparison["comparison_failed"] = any_failed
             target_list = baseline_comparison_pages if current["type"] == "page" else baseline_comparison_actions
             target_list.append(comparison)
+
+        baseline_comparison_pages = sorted(
+            baseline_comparison_pages,
+            key=lambda item: (not item.get("comparison_failed", False), item.get("name", ""))
+        )
+        baseline_comparison_actions = sorted(
+            baseline_comparison_actions,
+            key=lambda item: (not item.get("comparison_failed", False), item.get("name", ""))
+        )
 
         degradation_rate = round(float(failed / count) * 100, 2) if count else 0
         return baseline_comparison_pages, baseline_comparison_actions, degradation_rate, aggregated_baseline
@@ -199,28 +220,28 @@ class UIEmailNotification:
     def _aggregate_results_by_identifier(self, results, is_baseline):
         """Aggregate results by identifier for comparison."""
         aggregated = {}
-        
+
         for result in results:
             identifier = result["identifier"]
             if identifier not in aggregated:
                 aggregated[identifier] = {"name": result["name"], "type": result["type"]}
-            
+
             metrics = ["load_time", "fcp", "lcp", "tbt", "ttfb"] if result["type"] == "page" else ["tbt", "cls", "inp"]
-            
+
             for metric in metrics:
                 if metric not in result:
-                    self._append_metric_value(aggregated[identifier], metric, "Requires newer\nLighthouse version")
+                    self._append_metric_value(aggregated[identifier], metric, "No data")
                     continue
-                
+
                 value = result[metric]
-                if value == "Requires newer\nLighthouse version":
+                if value == "No data":
                     self._append_metric_value(aggregated[identifier], metric, value)
                 elif is_baseline:
                     converted = self._safe_metric_conversion(value, metric, is_cls=(metric == "cls"))
                     self._append_metric_value(aggregated[identifier], metric, converted)
                 else:
                     self._append_metric_value(aggregated[identifier], metric, float(value))
-        
+
         return aggregated
 
     def _append_metric_value(self, target_dict, metric, value):
@@ -232,35 +253,34 @@ class UIEmailNotification:
     def _finalize_aggregated_results(self, aggregated_dict):
         """Convert aggregated metric lists to averages."""
         finalized = []
-        
+
         for identifier, data in aggregated_dict.items():
             result = {"identifier": identifier, "name": data["name"], "type": data["type"]}
-            
+
             for metric in ["load_time", "fcp", "lcp", "tbt", "inp", "cls", "ttfb"]:
                 if metric not in data:
-                    result[metric] = "Requires newer\nLighthouse version"
+                    result[metric] = "No data"
                     continue
-                
+
                 values = data[metric]
-                if "Requires newer\nLighthouse version" in values:
-                    result[metric] = "Requires newer\nLighthouse version"
+                if "No data" in values:
+                    result[metric] = "No data"
                 else:
                     result[metric] = round(sum(values) / len(values), 2)
-            
-            finalized.append(result)
-        
-        return finalized
 
+            finalized.append(result)
+
+        return finalized
 
     def ui_email_notification(self):
         info = self._get_test_info()
         last_reports = self._get_last_report(info['name'], 10)
-        
+
         tests_data = []
         for each in last_reports:
             if each["test_status"]["status"] not in ["Finished", "Success", "Failed"] or len(tests_data) >= 5:
                 continue
-            
+
             report = {"pages": [], "actions": []}
             results_info = self._get_results_info(each["uid"])
             for result in results_info:
@@ -278,12 +298,12 @@ class UIEmailNotification:
         status = test_status.get("status", "PASSED")
         thresholds_total = report_info.get("thresholds_total", 0)
         thresholds_failed = report_info.get("thresholds_failed", 0)
-        
+
         if thresholds_total > 0:
             missed_thresholds = round((thresholds_failed / thresholds_total) * 100, 1)
         else:
             missed_thresholds = 0
-        
+
         if status == "Failed":
             color = RED
         elif status == "Finished":
@@ -294,20 +314,22 @@ class UIEmailNotification:
         thresholds_processor = ThresholdsComparison(
             self.gelloper_url, self.gelloper_token, self.galloper_project_id, self.report_id
         )
-        
+
         try:
             raw_thresholds = thresholds_processor.get_thresholds_info()
             print(f"[RAW THRESHOLDS] Total: {len(raw_thresholds)}")
-            
+
             thresholds_grouped = thresholds_processor.get_thresholds_grouped_by_scope(
                 report_info['name'], test_environment
             )
-            print(f"[THRESHOLDS] Loaded {sum(len(v) for v in thresholds_grouped.values())} across {len(thresholds_grouped)} scopes")
+            print(
+                f"[THRESHOLDS] Loaded {sum(len(v) for v in thresholds_grouped.values())} across {len(thresholds_grouped)} scopes")
         except Exception as e:
             print(f"[WARNING] Could not load thresholds: {e}")
             thresholds_grouped = {}
 
-        local_missed_thresholds = self._apply_threshold_colors(results_info, thresholds_grouped, thresholds_processor, report_info)
+        local_missed_thresholds = self._apply_threshold_colors(results_info, thresholds_grouped, thresholds_processor,
+                                                               report_info)
         self._convert_result_units(results_info)
 
         try:
@@ -323,7 +345,8 @@ class UIEmailNotification:
         degradation_rate = 0
 
         if base_id:
-            baseline_report_info = self._get_url(f"/ui_performance/reports/{self.galloper_project_id}?report_id={base_id}")
+            baseline_report_info = self._get_url(
+                f"/ui_performance/reports/{self.galloper_project_id}?report_id={base_id}")
             baseline_info = self._get_results_info(base_id)
             baseline_test_url = f"{self.gelloper_url}/-/performance/ui/results?result_id={baseline_report_info['id']}"
             baseline_test_date = baseline_report_info['start_time']
@@ -394,7 +417,7 @@ class UIEmailNotification:
         return self._get_url(f"/ui_performance/results/{self.galloper_project_id}/{report_id}?order=asc")
 
     def _get_email_body(self, t_params, results_info, page_comparison, action_comparison,
-                        baseline_comparison_pages, baseline_comparison_actions, degradation_rate, 
+                        baseline_comparison_pages, baseline_comparison_actions, degradation_rate,
                         missed_thresholds, baseline_info, aggregated_baseline):
         env = Environment(loader=FileSystemLoader('./templates'))
         template = env.get_template("ui_email_template.html")
@@ -418,21 +441,19 @@ class UIEmailNotification:
             raise Exception(f"Error {resp}")
         return resp.json()
 
-
-
     @staticmethod
     def create_ui_metrics_chart_pages(builds):
         labels, x, ttfb, tbt, lcp = [], [], [], [], []
         ttfb_original, tbt_original, lcp_original = [], [], []
-        
+
         for idx, test in enumerate(builds, 1):
             labels.append(test['date'])
             x.append(idx)
-            
+
             ttfb_original.append(test['ttfb'])
             tbt_original.append(test['tbt'])
             lcp_original.append(test['lcp'])
-            
+
             ttfb.append(round(test['ttfb'], 2) if isinstance(test['ttfb'], (int, float)) else 0)
             tbt.append(round(test['tbt'], 2) if isinstance(test['tbt'], (int, float)) else 0)
             lcp.append(round(test['lcp'], 2) if isinstance(test['lcp'], (int, float)) else 0)
@@ -458,7 +479,7 @@ class UIEmailNotification:
             'values': x,
             'labels': labels[::-1]
         }
-        
+
         ui_metrics_chart_pages(datapoints)
         with open('/tmp/ui_metrics_pages.png', 'rb') as fp:
             image = MIMEImage(fp.read())
@@ -469,15 +490,15 @@ class UIEmailNotification:
     def create_ui_metrics_chart_actions(builds):
         labels, x, cls, tbt, inp = [], [], [], [], []
         cls_original, tbt_original, inp_original = [], [], []
-        
+
         for idx, test in enumerate(builds, 1):
             labels.append(test['date'])
             x.append(idx)
-            
+
             cls_original.append(test['cls'])
             tbt_original.append(test['tbt'])
             inp_original.append(test['inp'])
-            
+
             cls.append(round(test['cls'], 2) if isinstance(test['cls'], (int, float)) else 0)
             tbt.append(round(test['tbt'], 2) if isinstance(test['tbt'], (int, float)) else 0)
             inp.append(round(test['inp'], 2) if isinstance(test['inp'], (int, float)) else 0)
@@ -503,7 +524,7 @@ class UIEmailNotification:
             'values': x,
             'labels': labels[::-1]
         }
-        
+
         ui_metrics_chart_actions(datapoints)
         with open('/tmp/ui_metrics_actions.png', 'rb') as fp:
             image = MIMEImage(fp.read())
@@ -515,12 +536,12 @@ class UIEmailNotification:
         """Convert UTC datetime string to CET/CEST timezone."""
         utc_tz = pytz.UTC
         cet_tz = pytz.timezone('Europe/Paris')
-        
+
         date_part = short_date_str.split('T')[0]
         year_part = date_part.split('-')[0]
         full_datetime_str = f"20{short_date_str}" if len(year_part) == 2 else short_date_str
-        
+
         utc_dt = utc_tz.localize(datetime.strptime(full_datetime_str, '%Y-%m-%dT%H:%M:%S'))
         cet_dt = utc_dt.astimezone(cet_tz)
-        
+
         return cet_dt.strftime(output_format)


### PR DESCRIPTION
# UI baseline comparison: page/action-level failure

## Summary
- Switch UI baseline comparison to evaluate failure at the page/action level (any metric breach marks the item failed).
- Recompute degradation rate using page/action counts instead of per-metric counts.
- Sort baseline comparison tables with failed items first.

## Rationale
- This reduces noise in baseline reports by collapsing multiple metric breaches into a single failure per page/action.
- The degradation rate now reflects the proportion of impacted pages/actions rather than the number of metric breaches.

## Changes
- `ui_email_notification.py`: track `any_failed` per page/action, increment totals once per item, and add `comparison_failed` to drive sorting.
- `ui_email_notification.py`: sort `baseline_comparison_pages` and `baseline_comparison_actions` with failures at the top (alphabetical within groups).
- `ui_email_notification.py`: replace "Requires newer Lighthouse version" placeholders with "No data" for UI page/action metrics.
- `templates/ui_email_template.html`: move baseline/threshold notes to the end of the email body and align "No data" comparisons in tables.

## Notes
- Items with only "No data" metrics are excluded from the degradation rate because they are not comparable.

## Testing
- Not run (logic-only change).
