### PR TITLE
Update metrics for UI baseline comparison

### DIFF
--- a/report_builder.py
+++ b/report_builder.py
@@ -583,6 +583,10 @@ class ReportBuilder:
             baseline_report_id = self._get_baseline_api_report_id(args, baseline_build_id)
             if baseline_report_id:
                 test_params["baseline_report_url"] = f"{args['galloper_url']}/-/performance/backend/results?result_id={baseline_report_id}"
+        if report_data:
+            report_id = report_data.get("id") or report_data.get("report_id")
+            if report_id:
+                test_params["current_report_url"] = f"{args['galloper_url']}/-/performance/backend/results?result_id={report_id}"
         for param in params:
             test_params[param] = test[0][param]
         

--- a/templates/backend_email_template.html
+++ b/templates/backend_email_template.html
@@ -130,6 +130,13 @@
             </td>
             {% endif %}
         </tr>
+        {% if t_params.current_report_url %}
+        <tr>
+            <td colspan="3" style="padding: 8px 12px;">
+                <a href="{{ t_params.current_report_url }}" style="color: #875FFC; text-decoration: none; font-size: 14px;">View current test report →</a>
+            </td>
+        </tr>
+        {% endif %}
         {% if t_params.baseline_status != 'N/A' and t_params.baseline_status != 'missing' and t_params.baseline_report_url %}
         <tr>
             <td colspan="3" style="padding: 8px 12px;">
@@ -151,111 +158,6 @@
     </div>
     {% endif %}
 
-    <!-- YELLOW WARNINGS (Deviation) - display first -->
-    {% if t_params.baseline_deviation_warning %}
-    <div style="margin: 24px 12px 12px; padding: 12px; background-color: #FFF9E6; border-left: 4px solid #FFC107; border-radius: 4px;">
-        <p style="margin: 0; color: #8B6F00; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> Baseline has configured acceptable deviation. Validation results take into account the allowed deviation range when comparing actual values against baseline.
-        </p>
-    </div>
-    {% endif %}
-
-    {% if t_params.sla_deviation_warning %}
-    <div style="margin: 12px 12px; padding: 12px; background-color: #FFF9E6; border-left: 4px solid #FFC107; border-radius: 4px;">
-        <p style="margin: 0; color: #8B6F00; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> SLA has configured acceptable deviation. Validation results take into account the allowed deviation range when comparing actual values against SLA thresholds.
-        </p>
-    </div>
-    {% endif %}
-
-    <!-- BLUE WARNINGS (Configuration) - display second -->
-    {% if t_params.baseline_metric_warning %}
-    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
-        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.baseline_metric_warning }}
-        </p>
-    </div>
-    {% endif %}
-
-    {% if t_params.baseline_status == 'missing' %}
-    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
-        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.baseline_note }}
-        </p>
-    </div>
-    {% endif %}
-
-    {% if baseline_and_thresholds.has_disabled_summary_baseline and not t_params.baseline_metric_warning %}
-    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
-        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> Summary results baseline comparison is disabled. Enable "Summary results" in Quality Gate configuration to see baseline for general metrics.
-        </p>
-    </div>
-    {% endif %}
-
-    {% if baseline_and_thresholds.has_disabled_baseline and not t_params.baseline_metric_warning %}
-    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
-        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> Per request baseline comparison is disabled. Enable "Per request results" in Quality Gate configuration to see baseline for individual requests.
-        </p>
-    </div>
-    {% endif %}
-
-    {% if t_params.baseline_info_warning %}
-    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
-        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.baseline_info_warning }}
-        </p>
-    </div>
-    {% endif %}
-
-    {% if t_params.baseline_disabled_metrics_info %}
-    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
-        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.baseline_disabled_metrics_info }}
-        </p>
-    </div>
-    {% endif %}
-
-    {% if t_params.sla_metric_warning %}
-    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
-        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.sla_metric_warning }}
-        </p>
-    </div>
-    {% endif %}
-
-    {% if t_params.sla_disabled_metrics_info %}
-    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
-        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.sla_disabled_metrics_info }}
-        </p>
-    </div>
-    {% endif %}
-
-    {% if t_params.sla_info_warning %}
-    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
-        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.sla_info_warning }}
-        </p>
-    </div>
-    {% endif %}
-
-    {% if t_params.sla_multiple_metrics_info %}
-    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
-        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.sla_multiple_metrics_info }}
-        </p>
-    </div>
-    {% endif %}
-
-    {% if baseline_and_thresholds.has_missing_sla and not baseline_and_thresholds.show_threshold_column and not t_params.sla_metric_warning and not t_params.sla_info_warning and t_params.summary_rt_check %}
-    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
-        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> SLA thresholds are not configured for {{ general_metrics.comparison_metric }} metric. Configure SLA thresholds in Thresholds section to see threshold values and differences in Request metrics and General metrics tables.
-        </p>
-    </div>
-    {% endif %}
     <div style="margin-top: 24px;">
         <table style="width: 100%;">
             <tbody>
@@ -525,6 +427,112 @@
         {% endfor %}
         </tbody>
     </table>
+
+    <!-- YELLOW WARNINGS (Deviation) - display first -->
+    {% if t_params.baseline_deviation_warning %}
+    <div style="margin: 24px 12px 12px; padding: 12px; background-color: #FFF9E6; border-left: 4px solid #FFC107; border-radius: 4px;">
+        <p style="margin: 0; color: #8B6F00; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> Baseline has configured acceptable deviation. Validation results take into account the allowed deviation range when comparing actual values against baseline.
+        </p>
+    </div>
+    {% endif %}
+
+    {% if t_params.sla_deviation_warning %}
+    <div style="margin: 12px 12px; padding: 12px; background-color: #FFF9E6; border-left: 4px solid #FFC107; border-radius: 4px;">
+        <p style="margin: 0; color: #8B6F00; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> SLA has configured acceptable deviation. Validation results take into account the allowed deviation range when comparing actual values against SLA thresholds.
+        </p>
+    </div>
+    {% endif %}
+
+    <!-- BLUE WARNINGS (Configuration) - display second -->
+    {% if t_params.baseline_metric_warning %}
+    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
+        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.baseline_metric_warning }}
+        </p>
+    </div>
+    {% endif %}
+
+    {% if t_params.baseline_status == 'missing' %}
+    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
+        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.baseline_note }}
+        </p>
+    </div>
+    {% endif %}
+
+    {% if baseline_and_thresholds.has_disabled_summary_baseline and not t_params.baseline_metric_warning %}
+    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
+        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> Summary results baseline comparison is disabled. Enable "Summary results" in Quality Gate configuration to see baseline for general metrics.
+        </p>
+    </div>
+    {% endif %}
+
+    {% if baseline_and_thresholds.has_disabled_baseline and not t_params.baseline_metric_warning %}
+    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
+        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> Per request baseline comparison is disabled. Enable "Per request results" in Quality Gate configuration to see baseline for individual requests.
+        </p>
+    </div>
+    {% endif %}
+
+    {% if t_params.baseline_info_warning %}
+    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
+        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.baseline_info_warning }}
+        </p>
+    </div>
+    {% endif %}
+
+    {% if t_params.baseline_disabled_metrics_info %}
+    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
+        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.baseline_disabled_metrics_info }}
+        </p>
+    </div>
+    {% endif %}
+
+    {% if t_params.sla_metric_warning %}
+    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
+        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.sla_metric_warning }}
+        </p>
+    </div>
+    {% endif %}
+
+    {% if t_params.sla_disabled_metrics_info %}
+    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
+        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.sla_disabled_metrics_info }}
+        </p>
+    </div>
+    {% endif %}
+
+    {% if t_params.sla_info_warning %}
+    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
+        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.sla_info_warning }}
+        </p>
+    </div>
+    {% endif %}
+
+    {% if t_params.sla_multiple_metrics_info %}
+    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
+        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.sla_multiple_metrics_info }}
+        </p>
+    </div>
+    {% endif %}
+
+    {% if baseline_and_thresholds.has_missing_sla and not baseline_and_thresholds.show_threshold_column and not t_params.sla_metric_warning and not t_params.sla_info_warning and t_params.summary_rt_check %}
+    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
+        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> SLA thresholds are not configured for {{ general_metrics.comparison_metric }} metric. Configure SLA thresholds in Thresholds section to see threshold values and differences in Request metrics and General metrics tables.
+        </p>
+    </div>
+    {% endif %}
 
 </div>
 

--- a/templates/backend_email_template.html
+++ b/templates/backend_email_template.html
@@ -43,7 +43,7 @@
         </p>
     </div>
     {% endif %}
-    
+
     {% if t_params.sla_info_block_debug %}
     <div style="margin: 12px; padding: 12px; background-color: #FFE4E1; border-left: 4px solid #FF6347; border-radius: 4px;">
         <p style="margin: 0 0 8px 0; color: #8B0000; font-size: 12px; font-weight: 700;">
@@ -67,7 +67,7 @@
         <p style="margin: 0; font-size: 12px; color: #856404; line-height: 18px;">
             <strong>sla_has_every:</strong> {{ t_params.debug_info.sla_has_every }}<br>
             <strong>comparison_metric:</strong> {{ t_params.debug_info.comparison_metric }}<br>
-            
+
             <strong>INPUT thresholds (parameter passed to method):</strong><br>
             {% if t_params.debug_info.input_thresholds %}
                 {% for th in t_params.debug_info.input_thresholds %}
@@ -76,7 +76,7 @@
             {% else %}
                 &nbsp;&nbsp;&nbsp;&nbsp;none<br>
             {% endif %}
-            
+
             <strong>API thresholds (fetched from Galloper for baseline):</strong><br>
             {% if t_params.debug_info.api_thresholds %}
                 {% for th in t_params.debug_info.api_thresholds %}
@@ -85,7 +85,7 @@
             {% else %}
                 &nbsp;&nbsp;&nbsp;&nbsp;none<br>
             {% endif %}
-            
+
             <strong>ALL thresholds (before target filter in main loop):</strong><br>
             {% if t_params.debug_info.all_thresholds %}
                 {% for th in t_params.debug_info.all_thresholds %}
@@ -94,7 +94,7 @@
             {% else %}
                 &nbsp;&nbsp;&nbsp;&nbsp;none<br>
             {% endif %}
-            
+
             <strong>RT thresholds only (after target filter):</strong><br>
             {% if t_params.debug_info.rt_thresholds %}
                 {% for th in t_params.debug_info.rt_thresholds %}
@@ -103,7 +103,7 @@
             {% else %}
                 &nbsp;&nbsp;&nbsp;&nbsp;none<br>
             {% endif %}
-            
+
             {% if t_params.debug_info.threshold_lookups %}
             <strong>Threshold lookup samples (first 3 requests):</strong><br>
                 {% for lookup in t_params.debug_info.threshold_lookups %}
@@ -113,7 +113,7 @@
         </p>
     </div>
     {% endif %}
-    
+
     {% if t_params.debug_baseline_calculation %}
     <!-- DEBUG SECTION - Baseline Calculation -->
     <div style="margin: 24px 12px 20px 12px; padding: 12px; background: #E8F5E8; border: 1px solid #4CAF50; border-radius: 4px;">
@@ -123,17 +123,17 @@
             &nbsp;&nbsp;&nbsp;&nbsp;• summary_rt_check: {{ t_params.debug_baseline_calculation.summary_rt_check if t_params.debug_baseline_calculation.summary_rt_check is defined else 'N/A' }}<br>
             &nbsp;&nbsp;&nbsp;&nbsp;• summary_er_check: {{ t_params.debug_baseline_calculation.summary_er_check if t_params.debug_baseline_calculation.summary_er_check is defined else 'N/A' }}<br>
             &nbsp;&nbsp;&nbsp;&nbsp;• summary_tp_check: {{ t_params.debug_baseline_calculation.summary_tp_check if t_params.debug_baseline_calculation.summary_tp_check is defined else 'N/A' }}<br>
-            
+
             <strong>Per Request Metrics Checks:</strong><br>
             &nbsp;&nbsp;&nbsp;&nbsp;• per_request_rt_check: {{ t_params.debug_baseline_calculation.per_request_rt_check if t_params.debug_baseline_calculation.per_request_rt_check is defined else 'N/A' }}<br>
             &nbsp;&nbsp;&nbsp;&nbsp;• per_request_er_check: {{ t_params.debug_baseline_calculation.per_request_er_check if t_params.debug_baseline_calculation.per_request_er_check is defined else 'N/A' }}<br>
             &nbsp;&nbsp;&nbsp;&nbsp;• per_request_tp_check: {{ t_params.debug_baseline_calculation.per_request_tp_check if t_params.debug_baseline_calculation.per_request_tp_check is defined else 'N/A' }}<br>
-            
+
             <strong>Calculation Summary:</strong><br>
             &nbsp;&nbsp;&nbsp;&nbsp;• Total comparisons (metrics checked): {{ t_params.debug_baseline_calculation.total_comparisons if t_params.debug_baseline_calculation.total_comparisons is defined else 'N/A' }}<br>
             &nbsp;&nbsp;&nbsp;&nbsp;• Total violated (metrics failed): {{ t_params.debug_baseline_calculation.total_violated if t_params.debug_baseline_calculation.total_violated is defined else 'N/A' }}<br>
             &nbsp;&nbsp;&nbsp;&nbsp;• Failed rate (%): {{ "%.2f"|format(t_params.debug_baseline_calculation.performance_degradation_rate) if t_params.debug_baseline_calculation.performance_degradation_rate is defined else 'N/A' }}%<br>
-            
+
             <strong>"All" Row Metrics Details:</strong><br>
             {% if t_params.debug_baseline_calculation.all_details %}
                 {% for detail in t_params.debug_baseline_calculation.all_details %}
@@ -142,7 +142,7 @@
             {% else %}
                 &nbsp;&nbsp;&nbsp;&nbsp;none<br>
             {% endif %}
-            
+
             <strong>Individual Requests Details (first 15):</strong><br>
             {% if t_params.debug_baseline_calculation.individual_details %}
                 {% for detail in t_params.debug_baseline_calculation.individual_details %}
@@ -151,7 +151,7 @@
             {% else %}
                 &nbsp;&nbsp;&nbsp;&nbsp;none<br>
             {% endif %}
-            
+
             <strong>Counts:</strong><br>
             &nbsp;&nbsp;&nbsp;&nbsp;• All passed: {{ t_params.debug_baseline_calculation.all_passed if t_params.debug_baseline_calculation.all_passed is defined else 'N/A' }}<br>
             &nbsp;&nbsp;&nbsp;&nbsp;• All failed: {{ t_params.debug_baseline_calculation.all_failed if t_params.debug_baseline_calculation.all_failed is defined else 'N/A' }}<br>
@@ -160,7 +160,7 @@
         </p>
     </div>
     {% endif %}
-    
+
     <p style="margin: 24px 0 20px 0; padding: 0 12px; font-weight: 700; color: #525F7F;">Execution Summary</p>
     <table style="border-spacing: 10px;">
         <tr>
@@ -204,6 +204,13 @@
             </td>
             {% endif %}
         </tr>
+        {% if t_params.current_report_url %}
+        <tr>
+            <td colspan="3" style="padding: 8px 12px;">
+                <a href="{{ t_params.current_report_url }}" style="color: #875FFC; text-decoration: none; font-size: 14px;">View current test report →</a>
+            </td>
+        </tr>
+        {% endif %}
         {% if t_params.baseline_status != 'N/A' and t_params.baseline_status != 'missing' and t_params.baseline_report_url %}
         <tr>
             <td colspan="3" style="padding: 8px 12px;">

--- a/templates/backend_email_template.html
+++ b/templates/backend_email_template.html
@@ -232,88 +232,6 @@
     </div>
     {% endif %}
 
-    <!-- YELLOW WARNINGS (Deviation) - display first -->
-    {% if t_params.baseline_deviation_warning %}
-    <div style="margin: 24px 12px 12px; padding: 12px; background-color: #FFF9E6; border-left: 4px solid #FFC107; border-radius: 4px;">
-        <p style="margin: 0; color: #8B6F00; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> Baseline has configured acceptable deviation. Validation results take into account the allowed deviation range when comparing actual values against baseline.
-        </p>
-    </div>
-    {% endif %}
-
-    {% if t_params.sla_deviation_warning %}
-    <div style="margin: 12px 12px; padding: 12px; background-color: #FFF9E6; border-left: 4px solid #FFC107; border-radius: 4px;">
-        <p style="margin: 0; color: #8B6F00; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> SLA has configured acceptable deviation. Validation results take into account the allowed deviation range when comparing actual values against SLA thresholds.
-        </p>
-    </div>
-    {% endif %}
-
-    <!-- BLUE WARNINGS (Configuration) - display second -->
-    {% if t_params.baseline_metric_warning %}
-    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
-        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.baseline_metric_warning }}
-        </p>
-    </div>
-    {% endif %}
-
-    {% if t_params.baseline_status == 'missing' %}
-    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
-        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.baseline_note }}
-        </p>
-    </div>
-    {% endif %}
-
-    {% if t_params.baseline_info_warning %}
-    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
-        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.baseline_info_warning }}
-        </p>
-    </div>
-    {% endif %}
-
-    {% if t_params.baseline_disabled_metrics_info %}
-    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
-        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.baseline_disabled_metrics_info }}
-        </p>
-    </div>
-    {% endif %}
-
-    {% if t_params.sla_metric_warning %}
-    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
-        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.sla_metric_warning }}
-        </p>
-    </div>
-    {% endif %}
-
-    {% if t_params.sla_disabled_metrics_info %}
-    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
-        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.sla_disabled_metrics_info }}
-        </p>
-    </div>
-    {% endif %}
-
-    {% if t_params.sla_info_warning %}
-    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
-        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.sla_info_warning }}
-        </p>
-    </div>
-    {% endif %}
-
-    {% if t_params.sla_multiple_metrics_info %}
-    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
-        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
-            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.sla_multiple_metrics_info }}
-        </p>
-    </div>
-    {% endif %}
-
     <div style="margin-top: 24px;">
         <table style="width: 100%;">
             <tbody>
@@ -583,6 +501,88 @@
         {% endfor %}
         </tbody>
     </table>
+
+    <!-- YELLOW WARNINGS (Deviation) - display first -->
+    {% if t_params.baseline_deviation_warning %}
+    <div style="margin: 24px 12px 12px; padding: 12px; background-color: #FFF9E6; border-left: 4px solid #FFC107; border-radius: 4px;">
+        <p style="margin: 0; color: #8B6F00; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> Baseline has configured acceptable deviation. Validation results take into account the allowed deviation range when comparing actual values against baseline.
+        </p>
+    </div>
+    {% endif %}
+
+    {% if t_params.sla_deviation_warning %}
+    <div style="margin: 12px 12px; padding: 12px; background-color: #FFF9E6; border-left: 4px solid #FFC107; border-radius: 4px;">
+        <p style="margin: 0; color: #8B6F00; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> SLA has configured acceptable deviation. Validation results take into account the allowed deviation range when comparing actual values against SLA thresholds.
+        </p>
+    </div>
+    {% endif %}
+
+    <!-- BLUE WARNINGS (Configuration) - display second -->
+    {% if t_params.baseline_metric_warning %}
+    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
+        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.baseline_metric_warning }}
+        </p>
+    </div>
+    {% endif %}
+
+    {% if t_params.baseline_status == 'missing' %}
+    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
+        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.baseline_note }}
+        </p>
+    </div>
+    {% endif %}
+
+    {% if t_params.baseline_info_warning %}
+    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
+        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.baseline_info_warning }}
+        </p>
+    </div>
+    {% endif %}
+
+    {% if t_params.baseline_disabled_metrics_info %}
+    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
+        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.baseline_disabled_metrics_info }}
+        </p>
+    </div>
+    {% endif %}
+
+    {% if t_params.sla_metric_warning %}
+    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
+        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.sla_metric_warning }}
+        </p>
+    </div>
+    {% endif %}
+
+    {% if t_params.sla_disabled_metrics_info %}
+    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
+        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.sla_disabled_metrics_info }}
+        </p>
+    </div>
+    {% endif %}
+
+    {% if t_params.sla_info_warning %}
+    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
+        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.sla_info_warning }}
+        </p>
+    </div>
+    {% endif %}
+
+    {% if t_params.sla_multiple_metrics_info %}
+    <div style="margin: 12px 12px; padding: 12px; background-color: #E3F2FD; border-left: 4px solid #42A5F5; border-radius: 4px;">
+        <p style="margin: 0; color: #0D47A1; font-size: 12px;">
+            <span style="font-weight: 700;">ℹ️ Note:</span> {{ t_params.sla_multiple_metrics_info }}
+        </p>
+    </div>
+    {% endif %}
 
 </div>
 

--- a/ui_email_notification.py
+++ b/ui_email_notification.py
@@ -172,6 +172,7 @@ class UIEmailNotification:
 
             comparison = {"name": current["name"]}
             metrics = ["lcp", "tbt", "ttfb"] if current["type"] == "page" else ["tbt", "cls", "inp"]
+            impact_metric = "lcp" if current["type"] == "page" else "inp"
             any_failed = False
             any_checked = False
 
@@ -184,13 +185,16 @@ class UIEmailNotification:
                     comparison[f"{metric}_diff"] = "No data"
                     comparison[f"{metric}_diff_color"] = ""
                 else:
-                    any_checked = True
+                    if metric == impact_metric:
+                        any_checked = True
                     baseline_with_deviation = float(baseline[metric]) * (1 + (degradation_rate_setting / 100))
                     baseline_with_deviation = round(baseline_with_deviation, 2)
                     comparison[f"{metric}_baseline"] = baseline_with_deviation
                     diff = round(float(current[metric]) - baseline_with_deviation, 2)
                     if diff > 0:
-                        any_failed = True
+                        if metric == impact_metric:
+                            # Only the impact metric affects status for page/action comparison.
+                            any_failed = True
                         comparison[f"{metric}_diff"] = f'+{diff}'
                         comparison[f"{metric}_diff_color"] = "color:red;"
                     else:
@@ -386,7 +390,7 @@ class UIEmailNotification:
         start_time = t_params["start_time"]
         if len(start_time) > 16:
             start_time = start_time[:16]
-        subject = f"{status_word}{emoji}: {info['name']} ({start_time})"
+        subject = f"{emoji}: {info['name']} ({start_time})"
         date = datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
         email_body = self._get_email_body(
             t_params, results_info, page_comparison, action_comparison,


### PR DESCRIPTION
Summary:
- Update UI baseline comparison status to use only LCP for pages and INP for actions while still reporting all metric diffs.
- Add current backend test report link.
- Populate current backend report URL in report builder data for templates.
- Align backend email subject format with UI emails, including emoji, test name, and start time.
